### PR TITLE
Fix some quality-of-life problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,14 @@ jobs:
     - name: "Code imports"
       before_install: skip
       install:
-        - pip install isort
+        - pip install -r requirements/ci.txt
       before_script: skip
       script: isort --recursive --check-only --diff .
 
     - name: "Code format"
       before_install: skip
       install:
-        - pip install black
+        - pip install -r requirements/ci.txt
       before_script: skip
       script: black --check src
 

--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -72,4 +72,4 @@ using Open Zaak as the example.
 
 All done!
 
-.. _`documentation of Open Zaak`: https://open-zaak.readthedocs.io/en/latest/installation/configuration.html#configure-notificaties-api
+.. _`documentation of Open Zaak`: https://open-zaak.readthedocs.io/en/latest/installation/config/openzaak_config.html#configure-notificaties-api

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,4 @@
 # Core python libraries
-pip-tools
 psycopg2
 python-dotenv
 python-decouple # processing of envvar configs

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,30 +8,29 @@ alabaster==0.7.12         # via sphinx
 amqp==2.4.2               # via kombu
 babel==2.7.0              # via sphinx
 billiard==3.6.0.0         # via celery
-celery==4.3.0
+celery==4.3.0             # via -r requirements/base.in
 certifi==2018.11.29       # via requests
 cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
-click==7.0                # via pip-tools
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 cryptography==2.8         # via django-auth-adfs
-django-admin-index==1.2.2
+django-admin-index==1.2.2  # via -r requirements/base.in
 django-appconf==1.0.3     # via django-axes
-django-auth-adfs-db==0.2.0
+django-auth-adfs-db==0.2.0  # via -r requirements/base.in
 django-auth-adfs==1.3.1   # via django-auth-adfs-db
-django-axes==4.5.4
-django-choices==1.6.2
-django-cors-middleware==1.3.1
+django-axes==4.5.4        # via -r requirements/base.in
+django-choices==1.6.2     # via -r requirements/base.in, vng-api-common
+django-cors-middleware==1.3.1  # via -r requirements/base.in
 django-filter==2.1.0      # via vng-api-common
 django-ipware==2.1.0      # via django-axes
-django-markup==1.3
+django-markup==1.3        # via -r requirements/base.in
 django-ordered-model==2.1.0  # via django-admin-index
-django-redis==4.10.0
+django-redis==4.10.0      # via -r requirements/base.in
 django-solo==1.1.3        # via django-auth-adfs-db, vng-api-common
-django==2.2.11
+django==2.2.11            # via -r requirements/base.in, django-appconf, django-auth-adfs, django-auth-adfs-db, django-axes, django-choices, django-filter, django-markup, django-redis, drf-nested-routers, drf-yasg, vng-api-common
 djangorestframework-camel-case==1.0.3  # via vng-api-common
-djangorestframework==3.9.4
+djangorestframework==3.9.4  # via -r requirements/base.in, drf-nested-routers, drf-yasg, vng-api-common
 docutils==0.15            # via sphinx
 drf-nested-routers==0.91  # via vng-api-common
 drf-yasg==1.16.0          # via vng-api-common
@@ -44,29 +43,28 @@ isodate==0.6.0            # via vng-api-common
 itypes==1.1.0             # via coreapi
 jinja2==2.10.1            # via coreschema, sphinx
 kombu==4.5.0              # via celery
-markdown==3.0.1
+markdown==3.0.1           # via -r requirements/base.in
 markupsafe==1.1.1         # via jinja2
 oyaml==0.7                # via vng-api-common
 packaging==19.0           # via sphinx
-pika==0.13.1
-pip-tools==4.2.0
-psycopg2==2.8.2
+pika==0.13.1              # via -r requirements/base.in
+psycopg2==2.8.2           # via -r requirements/base.in
 pycparser==2.20           # via cffi
 pygments==2.4.2           # via sphinx
 pyjwt==1.7.1              # via django-auth-adfs, gemma-zds-client, vng-api-common
 pyparsing==2.4.1.1        # via packaging
-python-decouple==3.1
-python-dotenv==0.10.1
-pytz==2019.1
+python-decouple==3.1      # via -r requirements/base.in
+python-dotenv==0.10.1     # via -r requirements/base.in
+pytz==2019.1              # via -r requirements/base.in, babel, celery, django, django-axes
 pyyaml==3.13              # via gemma-zds-client, oyaml, vng-api-common
-raven==6.10.0
+raven==6.10.0             # via -r requirements/base.in
 redis==3.3.11             # via django-redis
 requests==2.21.0          # via coreapi, django-auth-adfs, gemma-zds-client, sphinx, vng-api-common
 ruamel.yaml==0.15.89      # via drf-yasg
-six==1.12.0               # via cryptography, django-appconf, django-markup, drf-yasg, isodate, packaging, pip-tools
+six==1.12.0               # via cryptography, django-appconf, django-markup, drf-yasg, isodate, packaging
 snowballstemmer==1.9.0    # via sphinx
-sphinx-rtd-theme==0.4.3
-sphinx==2.1.2
+sphinx-rtd-theme==0.4.3   # via -r requirements/base.in
+sphinx==2.1.2             # via -r requirements/base.in, sphinx-rtd-theme
 sphinxcontrib-applehelp==1.0.1  # via sphinx
 sphinxcontrib-devhelp==1.0.1  # via sphinx
 sphinxcontrib-htmlhelp==1.0.2  # via sphinx
@@ -77,9 +75,9 @@ sqlparse==0.3.0           # via django
 unidecode==1.0.23         # via vng-api-common
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.3           # via requests
-uwsgi==2.0.18
+uwsgi==2.0.18             # via -r requirements/base.in
 vine==1.3.0               # via amqp, celery
-vng-api-common==1.0.34
+vng-api-common==1.0.34    # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==46.1.3        # via sphinx
+# setuptools

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,96 +4,104 @@
 #
 #    pip-compile --no-index --output-file=requirements/ci.txt requirements/base.txt requirements/test-tools.in
 #
-alabaster==0.7.12
-amqp==2.4.2
-babel==2.7.0
+alabaster==0.7.12         # via -r requirements/base.txt, sphinx
+amqp==2.4.2               # via -r requirements/base.txt, kombu
+appdirs==1.4.4            # via black
+babel==2.7.0              # via -r requirements/base.txt, sphinx
 beautifulsoup4==4.8.1     # via webtest
-billiard==3.6.0.0
-celery==4.3.0
-certifi==2018.11.29
-cffi==1.14.0
-chardet==3.0.4
-click==7.0
-coreapi==2.3.3
-coreschema==0.0.4
-coverage==4.5.4
-cryptography==2.8
-django-admin-index==1.2.2
-django-appconf==1.0.3
-django-auth-adfs-db==0.2.0
-django-auth-adfs==1.3.1
-django-axes==4.5.4
-django-choices==1.6.2
-django-cors-middleware==1.3.1
-django-filter==2.1.0
-django-ipware==2.1.0
-django-markup==1.3
-django-ordered-model==2.1.0
-django-redis==4.10.0
-django-solo==1.1.3
-django-webtest==1.9.7
-django==2.2.11
-djangorestframework-camel-case==1.0.3
-djangorestframework==3.9.4
-docutils==0.15
-drf-nested-routers==0.91
-drf-yasg==1.16.0
-factory-boy==2.12.0
+billiard==3.6.0.0         # via -r requirements/base.txt, celery
+black==20.8b1             # via -r requirements/test-tools.in
+celery==4.3.0             # via -r requirements/base.txt
+certifi==2018.11.29       # via -r requirements/base.txt, requests
+cffi==1.14.0              # via -r requirements/base.txt, cryptography
+chardet==3.0.4            # via -r requirements/base.txt, requests
+click==7.1.2              # via black
+coreapi==2.3.3            # via -r requirements/base.txt, drf-yasg
+coreschema==0.0.4         # via -r requirements/base.txt, coreapi, drf-yasg
+coverage==4.5.4           # via -r requirements/test-tools.in
+cryptography==2.8         # via -r requirements/base.txt, django-auth-adfs
+django-admin-index==1.2.2  # via -r requirements/base.txt
+django-appconf==1.0.3     # via -r requirements/base.txt, django-axes
+django-auth-adfs-db==0.2.0  # via -r requirements/base.txt
+django-auth-adfs==1.3.1   # via -r requirements/base.txt, django-auth-adfs-db
+django-axes==4.5.4        # via -r requirements/base.txt
+django-choices==1.6.2     # via -r requirements/base.txt, vng-api-common
+django-cors-middleware==1.3.1  # via -r requirements/base.txt
+django-filter==2.1.0      # via -r requirements/base.txt, vng-api-common
+django-ipware==2.1.0      # via -r requirements/base.txt, django-axes
+django-markup==1.3        # via -r requirements/base.txt
+django-ordered-model==2.1.0  # via -r requirements/base.txt, django-admin-index
+django-redis==4.10.0      # via -r requirements/base.txt
+django-solo==1.1.3        # via -r requirements/base.txt, django-auth-adfs-db, vng-api-common
+django-webtest==1.9.7     # via -r requirements/test-tools.in
+django==2.2.11            # via -r requirements/base.txt, django-appconf, django-auth-adfs, django-auth-adfs-db, django-axes, django-choices, django-filter, django-markup, django-redis, drf-nested-routers, drf-yasg, vng-api-common
+djangorestframework-camel-case==1.0.3  # via -r requirements/base.txt, vng-api-common
+djangorestframework==3.9.4  # via -r requirements/base.txt, drf-nested-routers, drf-yasg, vng-api-common
+docutils==0.15            # via -r requirements/base.txt, sphinx
+drf-nested-routers==0.91  # via -r requirements/base.txt, vng-api-common
+drf-yasg==1.16.0          # via -r requirements/base.txt, vng-api-common
+factory-boy==2.12.0       # via -r requirements/test-tools.in
 faker==2.0.1              # via factory-boy
-freezegun==0.3.12
-gemma-zds-client==0.11.0
-idna==2.8
-imagesize==1.1.0
-inflection==0.3.1
-iso-639==0.4.5
-isodate==0.6.0
-itypes==1.1.0
-jinja2==2.10.1
-kombu==4.5.0
-markdown==3.0.1
-markupsafe==1.1.1
-oyaml==0.7
-packaging==19.0
-pika==0.13.1
-pip-tools==4.2.0
-psycopg2==2.8.2
-pycparser==2.20
-pygments==2.4.2
-pyjwt==1.7.1
-pyparsing==2.4.1.1
+freezegun==0.3.12         # via -r requirements/test-tools.in
+gemma-zds-client==0.11.0  # via -r requirements/base.txt, vng-api-common
+idna==2.8                 # via -r requirements/base.txt, requests
+imagesize==1.1.0          # via -r requirements/base.txt, sphinx
+inflection==0.3.1         # via -r requirements/base.txt, drf-yasg
+iso-639==0.4.5            # via -r requirements/base.txt, vng-api-common
+isodate==0.6.0            # via -r requirements/base.txt, vng-api-common
+isort==5.6.4              # via -r requirements/test-tools.in
+itypes==1.1.0             # via -r requirements/base.txt, coreapi
+jinja2==2.10.1            # via -r requirements/base.txt, coreschema, sphinx
+kombu==4.5.0              # via -r requirements/base.txt, celery
+markdown==3.0.1           # via -r requirements/base.txt
+markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
+mypy-extensions==0.4.3    # via black
+oyaml==0.7                # via -r requirements/base.txt, vng-api-common
+packaging==19.0           # via -r requirements/base.txt, sphinx
+pathspec==0.8.0           # via black
+pika==0.13.1              # via -r requirements/base.txt
+psycopg2==2.8.2           # via -r requirements/base.txt
+pycparser==2.20           # via -r requirements/base.txt, cffi
+pygments==2.4.2           # via -r requirements/base.txt, sphinx
+pyjwt==1.7.1              # via -r requirements/base.txt, django-auth-adfs, gemma-zds-client, vng-api-common
+pyparsing==2.4.1.1        # via -r requirements/base.txt, packaging
 python-dateutil==2.7.3    # via faker, freezegun
-python-decouple==3.1
-python-dotenv==0.10.1
-pytz==2019.1
-pyyaml==3.13
-raven==6.10.0
-redis==3.3.11
-requests-mock==1.6.0
-requests==2.21.0
-ruamel.yaml==0.15.89
-six==1.12.0
-snowballstemmer==1.9.0
+python-decouple==3.1      # via -r requirements/base.txt
+python-dotenv==0.10.1     # via -r requirements/base.txt
+pytz==2019.1              # via -r requirements/base.txt, babel, celery, django, django-axes
+pyyaml==3.13              # via -r requirements/base.txt, gemma-zds-client, oyaml, vng-api-common
+raven==6.10.0             # via -r requirements/base.txt
+redis==3.3.11             # via -r requirements/base.txt, django-redis
+regex==2020.10.28         # via black
+requests-mock==1.6.0      # via -r requirements/test-tools.in
+requests==2.21.0          # via -r requirements/base.txt, coreapi, django-auth-adfs, gemma-zds-client, requests-mock, sphinx, vng-api-common
+ruamel.yaml==0.15.89      # via -r requirements/base.txt, drf-yasg
+six==1.12.0               # via -r requirements/base.txt, cryptography, django-appconf, django-markup, drf-yasg, faker, freezegun, isodate, packaging, python-dateutil, requests-mock, webtest
+snowballstemmer==1.9.0    # via -r requirements/base.txt, sphinx
 soupsieve==1.9.5          # via beautifulsoup4
-sphinx-rtd-theme==0.4.3
-sphinx==2.1.2
-sphinxcontrib-applehelp==1.0.1
-sphinxcontrib-devhelp==1.0.1
-sphinxcontrib-htmlhelp==1.0.2
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.2
-sphinxcontrib-serializinghtml==1.1.3
-sqlparse==0.3.0
-tblib==1.4.0
+sphinx-rtd-theme==0.4.3   # via -r requirements/base.txt
+sphinx==2.1.2             # via -r requirements/base.txt, sphinx-rtd-theme
+sphinxcontrib-applehelp==1.0.1  # via -r requirements/base.txt, sphinx
+sphinxcontrib-devhelp==1.0.1  # via -r requirements/base.txt, sphinx
+sphinxcontrib-htmlhelp==1.0.2  # via -r requirements/base.txt, sphinx
+sphinxcontrib-jsmath==1.0.1  # via -r requirements/base.txt, sphinx
+sphinxcontrib-qthelp==1.0.2  # via -r requirements/base.txt, sphinx
+sphinxcontrib-serializinghtml==1.1.3  # via -r requirements/base.txt, sphinx
+sqlparse==0.3.0           # via -r requirements/base.txt, django
+tblib==1.4.0              # via -r requirements/test-tools.in
 text-unidecode==1.2       # via faker
-unidecode==1.0.23
-uritemplate==3.0.0
-urllib3==1.24.3
-uwsgi==2.0.18
-vine==1.3.0
-vng-api-common==1.0.34
+toml==0.10.2              # via black
+typed-ast==1.4.1          # via black
+typing-extensions==3.7.4.3  # via black
+unidecode==1.0.23         # via -r requirements/base.txt, vng-api-common
+uritemplate==3.0.0        # via -r requirements/base.txt, coreapi, drf-yasg
+urllib3==1.24.3           # via -r requirements/base.txt, requests
+uwsgi==2.0.18             # via -r requirements/base.txt
+vine==1.3.0               # via -r requirements/base.txt, amqp, celery
+vng-api-common==1.0.34    # via -r requirements/base.txt
 waitress==1.3.1           # via webtest
 webob==1.8.5              # via webtest
 webtest==2.0.33           # via django-webtest
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==46.1.3        # via sphinx
+# setuptools

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,10 +1,8 @@
 # Helpers
 bumpversion
-pip-tools
+pip-tools~=5.3.0
 
 # Code formatting
-black
-isort
 flake8
 
 # Debug tooling

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,114 +4,116 @@
 #
 #    pip-compile --no-index --output-file=requirements/dev.txt requirements/ci.txt requirements/dev.in
 #
-alabaster==0.7.12
-amqp==2.4.2
-appdirs==1.4.3            # via black
-attrs==19.3.0             # via black
-babel==2.7.0
-beautifulsoup4==4.8.1
-billiard==3.6.0.0
-black==19.10b0
-bumpversion==0.5.3
-celery==4.3.0
-certifi==2018.11.29
-cffi==1.14.0
-chardet==3.0.4
-click==7.0
-coreapi==2.3.3
-coreschema==0.0.4
-coverage==4.5.4
-cryptography==2.8
-django-admin-index==1.2.2
-django-appconf==1.0.3
-django-auth-adfs-db==0.2.0
-django-auth-adfs==1.3.1
-django-axes==4.5.4
-django-choices==1.6.2
-django-cors-middleware==1.3.1
-django-debug-toolbar==2.0
-django-extensions==2.2.1
-django-filter==2.1.0
-django-ipware==2.1.0
-django-markup==1.3
-django-ordered-model==2.1.0
-django-redis==4.10.0
-django-solo==1.1.3
-django-webtest==1.9.7
-django==2.2.11
-djangorestframework-camel-case==1.0.3
-djangorestframework==3.9.4
-docutils==0.15
-drf-nested-routers==0.91
-drf-yasg==1.16.0
+alabaster==0.7.12         # via -r requirements/ci.txt, sphinx
+amqp==2.4.2               # via -r requirements/ci.txt, kombu
+appdirs==1.4.4            # via -r requirements/ci.txt, black
+babel==2.7.0              # via -r requirements/ci.txt, flower, sphinx
+beautifulsoup4==4.8.1     # via -r requirements/ci.txt, webtest
+billiard==3.6.0.0         # via -r requirements/ci.txt, celery
+black==20.8b1             # via -r requirements/ci.txt
+bumpversion==0.5.3        # via -r requirements/dev.in
+celery==4.3.0             # via -r requirements/ci.txt, flower
+certifi==2018.11.29       # via -r requirements/ci.txt, requests
+cffi==1.14.0              # via -r requirements/ci.txt, cryptography
+chardet==3.0.4            # via -r requirements/ci.txt, requests
+click==7.1.2              # via -r requirements/ci.txt, black, pip-tools
+coreapi==2.3.3            # via -r requirements/ci.txt, drf-yasg
+coreschema==0.0.4         # via -r requirements/ci.txt, coreapi, drf-yasg
+coverage==4.5.4           # via -r requirements/ci.txt
+cryptography==2.8         # via -r requirements/ci.txt, django-auth-adfs
+django-admin-index==1.2.2  # via -r requirements/ci.txt
+django-appconf==1.0.3     # via -r requirements/ci.txt, django-axes
+django-auth-adfs-db==0.2.0  # via -r requirements/ci.txt
+django-auth-adfs==1.3.1   # via -r requirements/ci.txt, django-auth-adfs-db
+django-axes==4.5.4        # via -r requirements/ci.txt
+django-choices==1.6.2     # via -r requirements/ci.txt, vng-api-common
+django-cors-middleware==1.3.1  # via -r requirements/ci.txt
+django-debug-toolbar==2.0  # via -r requirements/dev.in
+django-extensions==2.2.1  # via -r requirements/dev.in
+django-filter==2.1.0      # via -r requirements/ci.txt, vng-api-common
+django-ipware==2.1.0      # via -r requirements/ci.txt, django-axes
+django-markup==1.3        # via -r requirements/ci.txt
+django-ordered-model==2.1.0  # via -r requirements/ci.txt, django-admin-index
+django-redis==4.10.0      # via -r requirements/ci.txt
+django-solo==1.1.3        # via -r requirements/ci.txt, django-auth-adfs-db, vng-api-common
+django-webtest==1.9.7     # via -r requirements/ci.txt
+django==2.2.11            # via -r requirements/ci.txt, django-appconf, django-auth-adfs, django-auth-adfs-db, django-axes, django-choices, django-debug-toolbar, django-filter, django-markup, django-redis, drf-nested-routers, drf-yasg, vng-api-common
+djangorestframework-camel-case==1.0.3  # via -r requirements/ci.txt, vng-api-common
+djangorestframework==3.9.4  # via -r requirements/ci.txt, drf-nested-routers, drf-yasg, vng-api-common
+docutils==0.15            # via -r requirements/ci.txt, sphinx
+drf-nested-routers==0.91  # via -r requirements/ci.txt, vng-api-common
+drf-yasg==1.16.0          # via -r requirements/ci.txt, vng-api-common
 entrypoints==0.3          # via flake8
-factory-boy==2.12.0
-faker==2.0.1
-flake8==3.7.9
-flower==0.9.3
-freezegun==0.3.12
-gemma-zds-client==0.11.0
-idna==2.8
-imagesize==1.1.0
-inflection==0.3.1
-iso-639==0.4.5
-isodate==0.6.0
-isort==4.3.21
-itypes==1.1.0
-jinja2==2.10.1
-kombu==4.5.0
-markdown==3.0.1
-markupsafe==1.1.1
+factory-boy==2.12.0       # via -r requirements/ci.txt
+faker==2.0.1              # via -r requirements/ci.txt, factory-boy
+flake8==3.7.9             # via -r requirements/dev.in
+flower==0.9.3             # via -r requirements/dev.in
+freezegun==0.3.12         # via -r requirements/ci.txt
+gemma-zds-client==0.11.0  # via -r requirements/ci.txt, vng-api-common
+idna==2.8                 # via -r requirements/ci.txt, requests
+imagesize==1.1.0          # via -r requirements/ci.txt, sphinx
+inflection==0.3.1         # via -r requirements/ci.txt, drf-yasg
+iso-639==0.4.5            # via -r requirements/ci.txt, vng-api-common
+isodate==0.6.0            # via -r requirements/ci.txt, vng-api-common
+isort==5.6.4              # via -r requirements/ci.txt
+itypes==1.1.0             # via -r requirements/ci.txt, coreapi
+jinja2==2.10.1            # via -r requirements/ci.txt, coreschema, sphinx
+kombu==4.5.0              # via -r requirements/ci.txt, celery
+markdown==3.0.1           # via -r requirements/ci.txt
+markupsafe==1.1.1         # via -r requirements/ci.txt, jinja2
 mccabe==0.6.1             # via flake8
-oyaml==0.7
-packaging==19.0
-pathspec==0.6.0           # via black
-pika==0.13.1
-pip-tools==4.2.0
-psycopg2==2.8.2
+mypy-extensions==0.4.3    # via -r requirements/ci.txt, black
+oyaml==0.7                # via -r requirements/ci.txt, vng-api-common
+packaging==19.0           # via -r requirements/ci.txt, sphinx
+pathspec==0.8.0           # via -r requirements/ci.txt, black
+pika==0.13.1              # via -r requirements/ci.txt
+pip-tools==5.3.1          # via -r requirements/dev.in
+psycopg2==2.8.2           # via -r requirements/ci.txt
 pycodestyle==2.5.0        # via flake8
-pycparser==2.20
+pycparser==2.20           # via -r requirements/ci.txt, cffi
 pyflakes==2.1.1           # via flake8
-pygments==2.4.2
-pyjwt==1.7.1
-pyparsing==2.4.1.1
-python-dateutil==2.7.3
-python-decouple==3.1
-python-dotenv==0.10.1
-pytz==2019.1
-pyyaml==3.13
-raven==6.10.0
-redis==3.3.11
-regex==2019.11.1          # via black
-requests-mock==1.6.0
-requests==2.21.0
-ruamel.yaml==0.15.89
-six==1.12.0
-snowballstemmer==1.9.0
-soupsieve==1.9.5
-sphinx-rtd-theme==0.4.3
-sphinx==2.1.2
-sphinxcontrib-applehelp==1.0.1
-sphinxcontrib-devhelp==1.0.1
-sphinxcontrib-htmlhelp==1.0.2
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.2
-sphinxcontrib-serializinghtml==1.1.3
-sqlparse==0.3.0
-tblib==1.4.0
-text-unidecode==1.2
-toml==0.10.0              # via black
+pygments==2.4.2           # via -r requirements/ci.txt, sphinx
+pyjwt==1.7.1              # via -r requirements/ci.txt, django-auth-adfs, gemma-zds-client, vng-api-common
+pyparsing==2.4.1.1        # via -r requirements/ci.txt, packaging
+python-dateutil==2.7.3    # via -r requirements/ci.txt, faker, freezegun
+python-decouple==3.1      # via -r requirements/ci.txt
+python-dotenv==0.10.1     # via -r requirements/ci.txt
+pytz==2019.1              # via -r requirements/ci.txt, babel, celery, django, django-axes, flower
+pyyaml==3.13              # via -r requirements/ci.txt, gemma-zds-client, oyaml, vng-api-common
+raven==6.10.0             # via -r requirements/ci.txt
+redis==3.3.11             # via -r requirements/ci.txt, django-redis
+regex==2020.10.28         # via -r requirements/ci.txt, black
+requests-mock==1.6.0      # via -r requirements/ci.txt
+requests==2.21.0          # via -r requirements/ci.txt, coreapi, django-auth-adfs, gemma-zds-client, requests-mock, sphinx, vng-api-common
+ruamel.yaml==0.15.89      # via -r requirements/ci.txt, drf-yasg
+six==1.12.0               # via -r requirements/ci.txt, cryptography, django-appconf, django-extensions, django-markup, drf-yasg, faker, freezegun, isodate, packaging, pip-tools, python-dateutil, requests-mock, webtest
+snowballstemmer==1.9.0    # via -r requirements/ci.txt, sphinx
+soupsieve==1.9.5          # via -r requirements/ci.txt, beautifulsoup4
+sphinx-rtd-theme==0.4.3   # via -r requirements/ci.txt
+sphinx==2.1.2             # via -r requirements/ci.txt, sphinx-rtd-theme
+sphinxcontrib-applehelp==1.0.1  # via -r requirements/ci.txt, sphinx
+sphinxcontrib-devhelp==1.0.1  # via -r requirements/ci.txt, sphinx
+sphinxcontrib-htmlhelp==1.0.2  # via -r requirements/ci.txt, sphinx
+sphinxcontrib-jsmath==1.0.1  # via -r requirements/ci.txt, sphinx
+sphinxcontrib-qthelp==1.0.2  # via -r requirements/ci.txt, sphinx
+sphinxcontrib-serializinghtml==1.1.3  # via -r requirements/ci.txt, sphinx
+sqlparse==0.3.0           # via -r requirements/ci.txt, django, django-debug-toolbar
+tblib==1.4.0              # via -r requirements/ci.txt
+text-unidecode==1.2       # via -r requirements/ci.txt, faker
+toml==0.10.2              # via -r requirements/ci.txt, black
 tornado==5.1.1            # via flower
-typed-ast==1.4.0          # via black
-unidecode==1.0.23
-uritemplate==3.0.0
-urllib3==1.24.3
-uwsgi==2.0.18
-vine==1.3.0
-vng-api-common==1.0.34
-waitress==1.3.1
-webob==1.8.5
-webtest==2.0.33
+typed-ast==1.4.1          # via -r requirements/ci.txt, black
+typing-extensions==3.7.4.3  # via -r requirements/ci.txt, black
+unidecode==1.0.23         # via -r requirements/ci.txt, vng-api-common
+uritemplate==3.0.0        # via -r requirements/ci.txt, coreapi, drf-yasg
+urllib3==1.24.3           # via -r requirements/ci.txt, requests
+uwsgi==2.0.18             # via -r requirements/ci.txt
+vine==1.3.0               # via -r requirements/ci.txt, amqp, celery
+vng-api-common==1.0.34    # via -r requirements/ci.txt
+waitress==1.3.1           # via -r requirements/ci.txt, webtest
+webob==1.8.5              # via -r requirements/ci.txt, webtest
+webtest==2.0.33           # via -r requirements/ci.txt, django-webtest
 
 # The following packages are considered to be unsafe in a requirements file:
-# setuptools==46.1.3        # via sphinx
+# pip
+# setuptools

--- a/requirements/test-tools.in
+++ b/requirements/test-tools.in
@@ -5,3 +5,7 @@ factory_boy
 freezegun
 requests-mock
 tblib
+
+# code linting/formatting
+black
+isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,6 @@ line_length = 88
 multi_line_output = 3
 skip = env,node_modules
 skip_glob = **/migrations/**
-not_skip = __init__.py
 known_django=django
 known_first_party=nrc
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/src/nrc/accounts/migrations/0003_add_adfs_admin_index.py
+++ b/src/nrc/accounts/migrations/0003_add_adfs_admin_index.py
@@ -17,7 +17,11 @@ def forward(apps, schema_editor):
 
     max_order = AppGroup.objects.aggregate(max=Max("order"))["max"] or 0
     config, _ = AppGroup.objects.get_or_create(
-        slug="configuration", defaults={"name": "Configuratie", "order": max_order + 1,}
+        slug="configuration",
+        defaults={
+            "name": "Configuratie",
+            "order": max_order + 1,
+        },
     )
     ct = ContentType.objects.get_for_model(ADFSConfig)
     config.models.add(ct)

--- a/src/nrc/api/tests/test_abonnement.py
+++ b/src/nrc/api/tests/test_abonnement.py
@@ -17,6 +17,13 @@ class AbonnementenTests(JWTAuthMixin, APITestCase):
 
     heeft_alle_autorisaties = True
 
+    def setUp(self):
+        super().setUp()
+
+        self.m = requests_mock.Mocker()
+        self.m.start()
+        self.addCleanup(self.m.stop)
+
     def test_abonnementen_create(self):
         """
         test /abonnementen POST:
@@ -90,6 +97,7 @@ class AbonnementenTests(JWTAuthMixin, APITestCase):
         attempt to create abonnement with nested nonexistent kanalen
         check if response contents status 400
         """
+        self.m.post("https://ref.tst.vng.cloud/zrc/api/v1/callbacks", status_code=204)
         abonnement_create_url = get_operation_url("abonnement_create")
         data = {
             "callbackUrl": "https://ref.tst.vng.cloud/zrc/api/v1/callbacks",

--- a/src/nrc/conf/ci.py
+++ b/src/nrc/conf/ci.py
@@ -16,7 +16,11 @@ CACHES = {
 
 for logger in LOGGING["loggers"].values():
     logger.update(
-        {"level": "CRITICAL", "handlers": [], "propagate": False,}
+        {
+            "level": "CRITICAL",
+            "handlers": [],
+            "propagate": False,
+        }
     )
 LOGGING["loggers"][""] = {"level": "CRITICAL", "handlers": []}
 

--- a/src/nrc/tests/commands/test_setup_configuration.py
+++ b/src/nrc/tests/commands/test_setup_configuration.py
@@ -28,7 +28,8 @@ class SetupConfigurationTests(TestCase):
         api_credential = APICredential.objects.get()
         self.assertEqual(api_credential.api_root, ac_root)
         self.assertEqual(
-            api_credential.label, f"Open Zaak {municipality}",
+            api_credential.label,
+            f"Open Zaak {municipality}",
         )
         self.assertEqual(
             api_credential.client_id, f"open-notificaties-{municipality.lower()}"


### PR DESCRIPTION
- Open Zaak documentation URL changed (was picked up by CI in #25 )
- `ref.tst.vng.cloud` no longer exists, causing a test to fail. This test shouldn't do real HTTP calls anyway, so added request mocking
- bumped isort & black versions, applied them and pinned CI on the versions specified in `requirements/ci.txt`