### PR TITLE
Fixes open-zaak/open-zaak#717 -- rewrite single-server README

### DIFF
--- a/deployment/single-server/README.md
+++ b/deployment/single-server/README.md
@@ -1,9 +1,31 @@
 # Single-server deployment
 
-This directory contains the tooling to deploy Open Notificaties against a single
-server. It has been tested with Debian 9 and 10.
+The [official documentation][docs] documents the installation procedure of Open
+Notificaties. If you're looking to install Open Notificaties, please follow that
+documentation.
 
-The application is deployed as docker containers, and the playbook will
-set up all the required dependencies.
+## For maintainers, power-users and devops engineers
 
-See [the docs](../../docs/installation/deployment/single_server.rst) on how to use this.
+This directory contains example [Ansible][Ansible] playbooks to deploy Open Notificaties.
+
+The playbooks are built around roles published on [Ansible Galaxy][Galaxy] by the
+community. This is also were we published the [Open Notificaties Collection][collection],
+which provides Open Notificaties-specific roles.
+
+## Requirements
+
+* A server with a supported Linux distribution (see the Ansible Collection docs for
+  supported distros).
+* Root access to the server
+* SSH access (with the root user)
+* A python virtualenv with the [requirements](../requirements.txt) installed
+
+## Deployment
+
+Follow the guide in the [official documentation][docs] - the steps still apply.
+
+
+[docs]: https://open-notificaties.readthedocs.io/en/stable/installation/deployment/single_server.html
+[Ansible]: https://www.ansible.com/
+[Galaxy]: https://galaxy.ansible.com/
+[collection]: https://github.com/open-zaak/ansible-collection


### PR DESCRIPTION
Instead of providing a short summary with instructions, the README
now refers to the documentation on readthedocs. The target users
of the code itself is now mentioned clearly.