### PR TITLE
Ensure uwsgi becomes PID 1

### DIFF
--- a/bin/celery_worker.sh
+++ b/bin/celery_worker.sh
@@ -13,7 +13,7 @@ ${SCRIPTPATH}/wait_for_db.sh
 ${SCRIPTPATH}/wait_for_rabbitmq.sh
 
 echo "Starting celery worker"
-celery worker \
+exec celery worker \
     --app nrc \
     -l $LOGLEVEL \
     --workdir src

--- a/bin/docker_start.sh
+++ b/bin/docker_start.sh
@@ -30,7 +30,7 @@ fi
 
 # Start server
 >&2 echo "Starting server"
-uwsgi \
+exec uwsgi \
     --http :$uwsgi_port \
     --http-keepalive \
     --manage-script-name \


### PR DESCRIPTION
Before this patch, uwsgi was not running as PID, but the docker_start
script got PID 1. This means that when the container runtime signals
to terminate the container, the signal was not actually passed down.

Container runtimes then usually follow that up with a SIGKILL (after
the SIGTERM), after a grace period.

Container restarts should be near-instant after this fix, because the
SIGTERM will be honored instead of having to wait the grace period and
have the container killed by SIGKILL.