### PR TITLE
Fix 1.2.2 regression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN npm run build
 FROM python:3.7-slim-bullseye AS production
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        media-types \
         procps \
         vim \
         postgresql-client \

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -254,7 +254,7 @@ uritemplate==3.0.0
     #   drf-yasg
 urllib3==1.24.3
     # via requests
-uwsgi==2.0.19.1
+uwsgi==2.0.20
     # via -r requirements/base.in
 vine==5.0.0
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -433,7 +433,7 @@ urllib3==1.24.3
     # via
     #   -r requirements/base.txt
     #   requests
-uwsgi==2.0.19.1
+uwsgi==2.0.20
     # via -r requirements/base.txt
 vine==5.0.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -479,7 +479,7 @@ urllib3==1.24.3
     # via
     #   -r requirements/ci.txt
     #   requests
-uwsgi==2.0.19.1
+uwsgi==2.0.20
     # via -r requirements/ci.txt
 vine==5.0.0
     # via


### PR DESCRIPTION
Swapping to debian-slim no longer provided us with a `/etc/mime.types` file, which is used by uwsgi.