### PR TITLE
Replace vng api common and bump some dependencies

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -25,7 +25,7 @@ mozilla-django-oidc-db
 # API libraries
 djangorestframework
 gemma-zds-client<1.0
-vng-api-common
+commonground-api-common
 
 # WSGI servers & monitoring - production oriented
 uwsgi

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ celery==5.2.6
     # via
     #   -r requirements/base.in
     #   flower
-certifi==2021.10.8
+certifi==2022.12.7
     # via
     #   requests
     #   self-certifi
@@ -61,7 +61,7 @@ cryptography==3.4.8
     #   pyopenssl
 deprecated==1.2.13
     # via redis
-django==3.2.14
+django==3.2.16
     # via
     #   -r requirements/base.in
     #   commonground-api-common
@@ -220,7 +220,7 @@ python-decouple==3.6
     # via -r requirements/base.in
 python-dotenv==0.20.0
     # via -r requirements/base.in
-pytz==2022.1
+pytz==2022.6
     # via
     #   -r requirements/base.in
     #   celery

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,6 +45,8 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
+commonground-api-common==1.9.0
+    # via -r requirements/base.in
 coreapi==2.3.3
     # via drf-yasg
 coreschema==0.0.4
@@ -62,6 +64,7 @@ deprecated==1.2.13
 django==3.2.14
     # via
     #   -r requirements/base.in
+    #   commonground-api-common
     #   django-admin-index
     #   django-auth-adfs
     #   django-auth-adfs-db
@@ -82,7 +85,6 @@ django==3.2.14
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
     #   notifications-api-common
-    #   vng-api-common
     #   zgw-consumers
 django-admin-index==2.0.0
     # via -r requirements/base.in
@@ -97,12 +99,12 @@ django-better-admin-arrayfield==1.4.2
 django-choices==1.7.2
     # via
     #   -r requirements/base.in
-    #   vng-api-common
+    #   commonground-api-common
     #   zgw-consumers
 django-cors-headers==3.11.0
     # via -r requirements/base.in
 django-filter==21.1
-    # via vng-api-common
+    # via commonground-api-common
 django-ipware==4.0.2
     # via django-axes
 django-markup==1.5
@@ -116,31 +118,31 @@ django-redis==5.2.0
 django-relativedelta==1.1.2
     # via zgw-consumers
 django-rest-framework-condition==0.1.1
-    # via vng-api-common
+    # via commonground-api-common
 django-sendfile2==0.7.0
     # via django-privates
 django-solo==2.0.0
     # via
+    #   commonground-api-common
     #   django-auth-adfs-db
     #   mozilla-django-oidc-db
     #   notifications-api-common
-    #   vng-api-common
     #   zgw-consumers
 djangorestframework==3.12.4
     # via
     #   -r requirements/base.in
+    #   commonground-api-common
     #   drf-nested-routers
     #   drf-yasg
     #   notifications-api-common
-    #   vng-api-common
 djangorestframework-camel-case==1.2.0
     # via
+    #   commonground-api-common
     #   notifications-api-common
-    #   vng-api-common
 drf-nested-routers==0.93.4
-    # via vng-api-common
+    # via commonground-api-common
 drf-yasg==1.20.0
-    # via vng-api-common
+    # via commonground-api-common
 face==20.1.1
     # via glom
 faker==13.15.1
@@ -150,8 +152,8 @@ flower==1.0.0
 gemma-zds-client==0.15.0
     # via
     #   -r requirements/base.in
+    #   commonground-api-common
     #   notifications-api-common
-    #   vng-api-common
     #   zgw-consumers
 glom==22.1.0
     # via mozilla-django-oidc-db
@@ -164,9 +166,9 @@ importlib-metadata==4.11.3
 inflection==0.5.1
     # via drf-yasg
 iso-639==0.4.5
-    # via vng-api-common
+    # via commonground-api-common
 isodate==0.6.1
-    # via vng-api-common
+    # via commonground-api-common
 itypes==1.2.0
     # via coreapi
 jinja2==3.1.0
@@ -184,9 +186,9 @@ mozilla-django-oidc==2.0.0
 mozilla-django-oidc-db==0.10.0
     # via -r requirements/base.in
 notifications-api-common==0.1.0
-    # via vng-api-common
+    # via commonground-api-common
 oyaml==1.0
-    # via vng-api-common
+    # via commonground-api-common
 packaging==21.3
     # via
     #   drf-yasg
@@ -201,9 +203,9 @@ pycparser==2.21
     # via cffi
 pyjwt==2.3.0
     # via
+    #   commonground-api-common
     #   django-auth-adfs
     #   gemma-zds-client
-    #   vng-api-common
 pyopenssl==20.0.1
     # via
     #   josepy
@@ -226,19 +228,19 @@ pytz==2022.1
     #   flower
 pyyaml==6.0
     # via
+    #   commonground-api-common
     #   gemma-zds-client
     #   oyaml
-    #   vng-api-common
 redis==4.2.0
     # via django-redis
 requests==2.27.1
     # via
+    #   commonground-api-common
     #   coreapi
     #   django-auth-adfs
     #   gemma-zds-client
     #   mozilla-django-oidc
     #   requests-mock
-    #   vng-api-common
     #   zgw-consumers
 requests-mock==1.9.3
     # via zgw-consumers
@@ -280,8 +282,6 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-vng-api-common==1.9.0
-    # via -r requirements/base.in
 wcwidth==0.2.5
     # via prompt-toolkit
 webencodings==0.5.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -39,7 +39,7 @@ celery==5.2.6
     # via
     #   -r requirements/base.txt
     #   flower
-certifi==2021.10.8
+certifi==2022.12.7
     # via
     #   -r requirements/base.txt
     #   requests
@@ -97,7 +97,7 @@ deprecated==1.2.13
     # via
     #   -r requirements/base.txt
     #   redis
-django==3.2.14
+django==3.2.16
     # via
     #   -r requirements/base.txt
     #   commonground-api-common
@@ -350,7 +350,7 @@ python-decouple==3.6
     # via -r requirements/base.txt
 python-dotenv==0.20.0
     # via -r requirements/base.txt
-pytz==2022.1
+pytz==2022.6
     # via
     #   -r requirements/base.txt
     #   celery

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -73,6 +73,8 @@ click-repl==0.2.0
     # via
     #   -r requirements/base.txt
     #   celery
+commonground-api-common==1.9.0
+    # via -r requirements/base.txt
 coreapi==2.3.3
     # via
     #   -r requirements/base.txt
@@ -98,6 +100,7 @@ deprecated==1.2.13
 django==3.2.14
     # via
     #   -r requirements/base.txt
+    #   commonground-api-common
     #   django-admin-index
     #   django-auth-adfs
     #   django-auth-adfs-db
@@ -118,7 +121,6 @@ django==3.2.14
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
     #   notifications-api-common
-    #   vng-api-common
     #   zgw-consumers
 django-admin-index==2.0.0
     # via -r requirements/base.txt
@@ -137,14 +139,14 @@ django-better-admin-arrayfield==1.4.2
 django-choices==1.7.2
     # via
     #   -r requirements/base.txt
-    #   vng-api-common
+    #   commonground-api-common
     #   zgw-consumers
 django-cors-headers==3.11.0
     # via -r requirements/base.txt
 django-filter==21.1
     # via
     #   -r requirements/base.txt
-    #   vng-api-common
+    #   commonground-api-common
 django-ipware==4.0.2
     # via
     #   -r requirements/base.txt
@@ -168,7 +170,7 @@ django-relativedelta==1.1.2
 django-rest-framework-condition==0.1.1
     # via
     #   -r requirements/base.txt
-    #   vng-api-common
+    #   commonground-api-common
 django-sendfile2==0.7.0
     # via
     #   -r requirements/base.txt
@@ -176,33 +178,33 @@ django-sendfile2==0.7.0
 django-solo==2.0.0
     # via
     #   -r requirements/base.txt
+    #   commonground-api-common
     #   django-auth-adfs-db
     #   mozilla-django-oidc-db
     #   notifications-api-common
-    #   vng-api-common
     #   zgw-consumers
 django-webtest==1.9.10
     # via -r requirements/test-tools.in
 djangorestframework==3.12.4
     # via
     #   -r requirements/base.txt
+    #   commonground-api-common
     #   drf-nested-routers
     #   drf-yasg
     #   notifications-api-common
-    #   vng-api-common
 djangorestframework-camel-case==1.2.0
     # via
     #   -r requirements/base.txt
+    #   commonground-api-common
     #   notifications-api-common
-    #   vng-api-common
 drf-nested-routers==0.93.4
     # via
     #   -r requirements/base.txt
-    #   vng-api-common
+    #   commonground-api-common
 drf-yasg==1.20.0
     # via
     #   -r requirements/base.txt
-    #   vng-api-common
+    #   commonground-api-common
 face==20.1.1
     # via
     #   -r requirements/base.txt
@@ -223,8 +225,8 @@ freezegun==1.2.1
 gemma-zds-client==0.15.0
     # via
     #   -r requirements/base.txt
+    #   commonground-api-common
     #   notifications-api-common
-    #   vng-api-common
     #   zgw-consumers
 glom==22.1.0
     # via
@@ -249,11 +251,11 @@ inflection==0.5.1
 iso-639==0.4.5
     # via
     #   -r requirements/base.txt
-    #   vng-api-common
+    #   commonground-api-common
 isodate==0.6.1
     # via
     #   -r requirements/base.txt
-    #   vng-api-common
+    #   commonground-api-common
 isort==5.9.3
     # via -r requirements/test-tools.in
 itypes==1.2.0
@@ -291,11 +293,11 @@ mypy-extensions==0.4.3
 notifications-api-common==0.1.0
     # via
     #   -r requirements/base.txt
-    #   vng-api-common
+    #   commonground-api-common
 oyaml==1.0
     # via
     #   -r requirements/base.txt
-    #   vng-api-common
+    #   commonground-api-common
 packaging==21.3
     # via
     #   -r requirements/base.txt
@@ -326,9 +328,9 @@ pyflakes==2.2.0
 pyjwt==2.3.0
     # via
     #   -r requirements/base.txt
+    #   commonground-api-common
     #   django-auth-adfs
     #   gemma-zds-client
-    #   vng-api-common
 pyopenssl==20.0.1
     # via
     #   -r requirements/base.txt
@@ -357,9 +359,9 @@ pytz==2022.1
 pyyaml==6.0
     # via
     #   -r requirements/base.txt
+    #   commonground-api-common
     #   gemma-zds-client
     #   oyaml
-    #   vng-api-common
 redis==4.2.0
     # via
     #   -r requirements/base.txt
@@ -369,12 +371,12 @@ regex==2020.10.28
 requests==2.27.1
     # via
     #   -r requirements/base.txt
+    #   commonground-api-common
     #   coreapi
     #   django-auth-adfs
     #   gemma-zds-client
     #   mozilla-django-oidc
     #   requests-mock
-    #   vng-api-common
     #   zgw-consumers
 requests-mock==1.9.3
     # via
@@ -440,8 +442,6 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-vng-api-common==1.9.0
-    # via -r requirements/base.txt
 waitress==2.1.1
     # via webtest
 wcwidth==0.2.5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -82,6 +82,8 @@ click-repl==0.2.0
     # via
     #   -r requirements/ci.txt
     #   celery
+commonground-api-common==1.9.0
+    # via -r requirements/ci.txt
 commonmark==0.9.1
     # via recommonmark
 coreapi==2.3.3
@@ -109,6 +111,7 @@ deprecated==1.2.13
 django==3.2.14
     # via
     #   -r requirements/ci.txt
+    #   commonground-api-common
     #   django-admin-index
     #   django-auth-adfs
     #   django-auth-adfs-db
@@ -131,7 +134,6 @@ django==3.2.14
     #   mozilla-django-oidc
     #   mozilla-django-oidc-db
     #   notifications-api-common
-    #   vng-api-common
     #   zgw-consumers
 django-admin-index==2.0.0
     # via -r requirements/ci.txt
@@ -150,7 +152,7 @@ django-better-admin-arrayfield==1.4.2
 django-choices==1.7.2
     # via
     #   -r requirements/ci.txt
-    #   vng-api-common
+    #   commonground-api-common
     #   zgw-consumers
 django-cors-headers==3.11.0
     # via -r requirements/ci.txt
@@ -161,7 +163,7 @@ django-extensions==3.1.5
 django-filter==21.1
     # via
     #   -r requirements/ci.txt
-    #   vng-api-common
+    #   commonground-api-common
 django-ipware==4.0.2
     # via
     #   -r requirements/ci.txt
@@ -185,7 +187,7 @@ django-relativedelta==1.1.2
 django-rest-framework-condition==0.1.1
     # via
     #   -r requirements/ci.txt
-    #   vng-api-common
+    #   commonground-api-common
 django-sendfile2==0.7.0
     # via
     #   -r requirements/ci.txt
@@ -193,25 +195,25 @@ django-sendfile2==0.7.0
 django-solo==2.0.0
     # via
     #   -r requirements/ci.txt
+    #   commonground-api-common
     #   django-auth-adfs-db
     #   mozilla-django-oidc-db
     #   notifications-api-common
-    #   vng-api-common
     #   zgw-consumers
 django-webtest==1.9.10
     # via -r requirements/ci.txt
 djangorestframework==3.12.4
     # via
     #   -r requirements/ci.txt
+    #   commonground-api-common
     #   drf-nested-routers
     #   drf-yasg
     #   notifications-api-common
-    #   vng-api-common
 djangorestframework-camel-case==1.2.0
     # via
     #   -r requirements/ci.txt
+    #   commonground-api-common
     #   notifications-api-common
-    #   vng-api-common
 docutils==0.17.1
     # via
     #   recommonmark
@@ -221,11 +223,11 @@ docutils==0.17.1
 drf-nested-routers==0.93.4
     # via
     #   -r requirements/ci.txt
-    #   vng-api-common
+    #   commonground-api-common
 drf-yasg==1.20.0
     # via
     #   -r requirements/ci.txt
-    #   vng-api-common
+    #   commonground-api-common
 face==20.1.1
     # via
     #   -r requirements/ci.txt
@@ -246,8 +248,8 @@ freezegun==1.2.1
 gemma-zds-client==0.15.0
     # via
     #   -r requirements/ci.txt
+    #   commonground-api-common
     #   notifications-api-common
-    #   vng-api-common
     #   zgw-consumers
 gitdb==4.0.9
     # via gitpython
@@ -279,11 +281,11 @@ inflection==0.5.1
 iso-639==0.4.5
     # via
     #   -r requirements/ci.txt
-    #   vng-api-common
+    #   commonground-api-common
 isodate==0.6.1
     # via
     #   -r requirements/ci.txt
-    #   vng-api-common
+    #   commonground-api-common
 isort==5.9.3
     # via -r requirements/ci.txt
 itypes==1.2.0
@@ -326,11 +328,11 @@ mypy-extensions==0.4.3
 notifications-api-common==0.1.0
     # via
     #   -r requirements/ci.txt
-    #   vng-api-common
+    #   commonground-api-common
 oyaml==1.0
     # via
     #   -r requirements/ci.txt
-    #   vng-api-common
+    #   commonground-api-common
 packaging==21.3
     # via
     #   -r requirements/ci.txt
@@ -378,9 +380,9 @@ pygments==2.4.2
 pyjwt==2.3.0
     # via
     #   -r requirements/ci.txt
+    #   commonground-api-common
     #   django-auth-adfs
     #   gemma-zds-client
-    #   vng-api-common
 pyopenssl==20.0.1
     # via
     #   -r requirements/ci.txt
@@ -410,9 +412,9 @@ pytz==2022.1
 pyyaml==6.0
     # via
     #   -r requirements/ci.txt
+    #   commonground-api-common
     #   gemma-zds-client
     #   oyaml
-    #   vng-api-common
 recommonmark==0.7.1
     # via -r requirements/dev.in
 redis==4.2.0
@@ -426,13 +428,13 @@ regex==2020.10.28
 requests==2.27.1
     # via
     #   -r requirements/ci.txt
+    #   commonground-api-common
     #   coreapi
     #   django-auth-adfs
     #   gemma-zds-client
     #   mozilla-django-oidc
     #   requests-mock
     #   sphinx
-    #   vng-api-common
     #   zgw-consumers
 requests-mock==1.9.3
     # via
@@ -530,8 +532,6 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-vng-api-common==1.9.0
-    # via -r requirements/ci.txt
 waitress==2.1.1
     # via
     #   -r requirements/ci.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -47,7 +47,7 @@ celery==5.2.6
     # via
     #   -r requirements/ci.txt
     #   flower
-certifi==2021.10.8
+certifi==2022.12.7
     # via
     #   -r requirements/ci.txt
     #   requests
@@ -108,7 +108,7 @@ deprecated==1.2.13
     # via
     #   -r requirements/ci.txt
     #   redis
-django==3.2.14
+django==3.2.16
     # via
     #   -r requirements/ci.txt
     #   commonground-api-common
@@ -402,7 +402,7 @@ python-decouple==3.6
     # via -r requirements/ci.txt
 python-dotenv==0.20.0
     # via -r requirements/ci.txt
-pytz==2022.1
+pytz==2022.6
     # via
     #   -r requirements/ci.txt
     #   babel


### PR DESCRIPTION
* replaced vng-api-common with commonground-api-common at same version
* bumped certifi
* bumped django to latest patch release
* bumped pytz to latest version (otherwise makemigrations picks up a new migration)