### PR TITLE
Creation of a command to delete outdated notifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ COPY ./bin/wait_for_rabbitmq.sh /wait_for_rabbitmq.sh
 COPY ./bin/docker_start.sh /start.sh
 COPY ./bin/celery_worker.sh /celery_worker.sh
 COPY ./bin/celery_flower.sh /celery_flower.sh
+COPY ./bin/celery_beat.sh /celery_beat.sh
 COPY ./bin/uninstall_adfs.sh ./bin/uninstall_django_auth_adfs_db.sql /app/bin/
 RUN mkdir /app/log
 

--- a/bin/celery_beat.sh
+++ b/bin/celery_beat.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+LOGLEVEL=${CELERY_LOGLEVEL:-INFO}
+
+mkdir -p celerybeat
+
+echo "Starting celery beat"
+exec celery --app nrc --workdir src beat \
+    -l $LOGLEVEL \
+    -s ../celerybeat/beat \
+    --pidfile=  # empty on purpose to avoid a bug when rebooting redis : https://github.com/open-formulieren/open-forms/pull/1187

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,16 @@ services:
       - rabbitmq
       - redis
 
+  celery-beat:
+    build: .
+    image: openzaak/open-notificaties:${TAG:-latest}
+    environment: *app-env
+    command: /celery_beat.sh
+    depends_on:
+      - db
+      - rabbitmq
+      - redis
+
   celery-flower:
     build: .
     environment: *app-env

--- a/docs/installation/configuration/env_config.md
+++ b/docs/installation/configuration/env_config.md
@@ -92,6 +92,8 @@ on Docker, since `localhost` is contained within the container:
 
 * `LOG_NOTIFICATIONS_IN_DB`: indicates whether or not sent notifications should be saved to the database (default: `False`).
 
+* `NOTIFICATION_NUMBER_OF_DAYS_RETAINED`: the number of days for which you wish to keep notifications (default: `30`).
+
 ### Celery
 
 * `CELERY_BROKER_URL`: the URL of the broker that will be used to actually send the notifications (default: `amqp://127.0.0.1:5672//`).

--- a/src/nrc/api/tasks.py
+++ b/src/nrc/api/tasks.py
@@ -2,6 +2,7 @@ import json
 import logging
 
 from django.conf import settings
+from django.core.management import call_command
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.translation import gettext_lazy as _
 
@@ -72,3 +73,11 @@ def deliver_message(sub_id: int, msg: dict, **kwargs) -> None:
                 attempt=kwargs.get("attempt", 1),
                 **response_init_kwargs
             )
+
+
+@app.task
+def clean_old_notifications() -> None:
+    """
+    cleans up old "Notificatie" and "NotificatieResponse"
+    """
+    call_command("clean_old_notifications")

--- a/src/nrc/conf/includes/base.py
+++ b/src/nrc/conf/includes/base.py
@@ -4,6 +4,7 @@ import os
 from django.urls import reverse_lazy
 
 import sentry_sdk
+from celery.schedules import crontab
 from corsheaders.defaults import default_headers as default_cors_headers
 
 from .api import *  # noqa
@@ -478,6 +479,13 @@ BROKER_URL = config("PUBLISH_BROKER_URL", "amqp://guest:guest@localhost:5672/%2F
 # Celery
 CELERY_BROKER_URL = config("CELERY_BROKER_URL", "amqp://127.0.0.1:5672//")
 CELERY_RESULT_BACKEND = config("CELERY_RESULT_BACKEND", "redis://localhost:6379/1")
+CELERY_BEAT_SCHEDULE = {
+    "clean-old-notifications": {
+        "task": "nrc.api.tasks.clean_old_notifications",
+        # https://docs.celeryproject.org/en/v4.4.7/userguide/periodic-tasks.html#crontab-schedules
+        "schedule": crontab(0, 0, day_of_month="1"),
+    },
+}
 
 # Retry settings for delivering notifications to subscriptions
 NOTIFICATION_DELIVERY_MAX_RETRIES = config("NOTIFICATION_DELIVERY_MAX_RETRIES", 5)
@@ -511,6 +519,13 @@ OIDC_AUTHENTICATION_CALLBACK_URL = "oidc_authentication_callback"
 OIDC_AUTHENTICATE_CLASS = "mozilla_django_oidc_db.views.OIDCAuthenticationRequestView"
 MOZILLA_DJANGO_OIDC_DB_CACHE = "oidc"
 MOZILLA_DJANGO_OIDC_DB_CACHE_TIMEOUT = 5 * 60
+
+#
+# Delete Notifications
+#
+NOTIFICATION_NUMBER_OF_DAYS_RETAINED = config(
+    "NOTIFICATION_NUMBER_OF_DAYS_RETAINED", 30
+)
 
 #
 # Elastic APM

--- a/src/nrc/datamodel/management/commands/clean_old_notifications.py
+++ b/src/nrc/datamodel/management/commands/clean_old_notifications.py
@@ -1,0 +1,24 @@
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from ...models import Notificatie
+
+
+class Command(BaseCommand):
+    def handle(self, **options):
+        date_limit = timezone.now() - timedelta(
+            days=settings.NOTIFICATION_NUMBER_OF_DAYS_RETAINED
+        )
+
+        notifications_filtered = Notificatie.objects.filter(
+            forwarded_msg__aanmaakdatum__lt=date_limit
+        ).delete()
+
+        self.stdout.write(
+            str(notifications_filtered[0])
+            + " notifications have been deleted : "
+            + str(notifications_filtered[1])
+        )

--- a/src/nrc/tests/commands/test_clean_old_notifications.py
+++ b/src/nrc/tests/commands/test_clean_old_notifications.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timedelta
+
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+from nrc.datamodel.models import Notificatie, NotificatieResponse
+from nrc.datamodel.tests.factories import (
+    KanaalFactory,
+    NotificatieFactory,
+    NotificatieResponseFactory,
+)
+
+
+class CleanOldNotificationsTests(TestCase):
+    @override_settings(NOTIFICATION_NUMBER_OF_DAYS_RETAINED=30)
+    def setUp(self) -> None:
+        self.kanaal = KanaalFactory.create(
+            naam="zaken", filters=["bron", "zaaktype", "vertrouwelijkheidaanduiding"]
+        )
+
+        in_month = (datetime.now() - timedelta(days=25)).strftime(
+            "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+        data = {"aanmaakdatum": in_month}
+        self.notif_in_month = NotificatieFactory.create(
+            forwarded_msg=data, kanaal=self.kanaal
+        )
+
+        out_month = (datetime.now() - timedelta(days=35)).strftime(
+            "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+        data2 = {"aanmaakdatum": out_month}
+        self.notif_out_month = NotificatieFactory.create(forwarded_msg=data2)
+
+        self.notif_response_in_month = NotificatieResponseFactory.create(
+            notificatie=self.notif_in_month
+        )
+        self.notif_response_out_month = NotificatieResponseFactory.create(
+            notificatie=self.notif_out_month
+        )
+
+    def test_objects_are_deleted(self):
+        self.assertEqual(Notificatie.objects.count(), 2)
+        self.assertEqual(NotificatieResponse.objects.count(), 2)
+
+        call_command("clean_old_notifications")
+
+        self.assertEqual(Notificatie.objects.count(), 1)
+        self.assertEqual(NotificatieResponse.objects.count(), 1)
+
+        self.assertEqual(Notificatie.objects.last(), self.notif_in_month)
+        self.assertEqual(
+            NotificatieResponse.objects.last(), self.notif_response_in_month
+        )
+
+    @override_settings(NOTIFICATION_NUMBER_OF_DAYS_RETAINED=60)
+    def test_change_of_period(self):
+        self.assertEqual(Notificatie.objects.count(), 2)
+
+        call_command("clean_old_notifications")
+
+        self.assertEqual(Notificatie.objects.count(), 2)
+        self.assertEqual(Notificatie.objects.last(), self.notif_out_month)
+        self.assertEqual(Notificatie.objects.first(), self.notif_in_month)
+
+        self.assertEqual(NotificatieResponse.objects.count(), 2)
+        self.assertEqual(
+            NotificatieResponse.objects.last(), self.notif_response_out_month
+        )
+        self.assertEqual(
+            NotificatieResponse.objects.first(), self.notif_response_in_month
+        )


### PR DESCRIPTION
#100 After several discussions we decided that the best way to deal with this problem in the long term was to create a Django command to remove old notifications. The default value is 30 days, which considerably increases query execution speed.