### PR TITLE
:sparkles: [#1637] added environmental variable to disable 2fa

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changes
 
 **New features**
 
+* [#1637] Added 2FA which can be disabled by the environment variable``DISABLE_2FA``.
 * Made user emails unique to prevent two users logging in with the same email, causing an error
 
 

--- a/src/nrc/conf/ci.py
+++ b/src/nrc/conf/ci.py
@@ -8,6 +8,8 @@ os.environ.setdefault("IS_HTTPS", "no")
 os.environ.setdefault("SECRET_KEY", "dummy")
 os.environ.setdefault("ENVIRONMENT", "CI")
 
+os.environ.setdefault("DISABLE_2FA", "no")
+
 from .includes.base import *  # noqa isort:skip
 
 CACHES = {

--- a/src/nrc/conf/dev.py
+++ b/src/nrc/conf/dev.py
@@ -15,6 +15,8 @@ os.environ.setdefault("DB_NAME", "opennotificaties")
 os.environ.setdefault("DB_USER", "opennotificaties")
 os.environ.setdefault("DB_PASSWORD", "opennotificaties")
 
+os.environ.setdefault("DISABLE_2FA", "yes")
+
 from .includes.base import *  # noqa isort:skip
 
 #
@@ -49,10 +51,6 @@ INSTALLED_APPS += ["debug_toolbar"]
 MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]
 INTERNAL_IPS = ("127.0.0.1",)
 DEBUG_TOOLBAR_CONFIG = {"INTERCEPT_REDIRECTS": False}
-
-# None of the authentication backends require two-factor authentication.
-if config("DISABLE_2FA", default=True):  # pragma: no cover
-    MAYKIN_2FA_ALLOW_MFA_BYPASS_BACKENDS = AUTHENTICATION_BACKENDS
 
 # in memory cache and django-axes don't get along.
 # https://django-axes.readthedocs.io/en/latest/configuration.html#known-configuration-problems

--- a/src/nrc/conf/includes/base.py
+++ b/src/nrc/conf/includes/base.py
@@ -79,8 +79,6 @@ LOG_NOTIFICATIONS_IN_DB = config("LOG_NOTIFICATIONS_IN_DB", default=False)
 # NOTE: We override this setting from open-api-framework, because removing
 # this would change the name to `nrc - admin`
 TWO_FACTOR_WEBAUTHN_RP_NAME = "Open Notificaties - admin"
-# add entries from AUTHENTICATION_BACKENDS that already enforce their own two-factor
-# auth, avoiding having some set up MFA again in the project.
 
 # RabbitMQ
 BROKER_URL = config("PUBLISH_BROKER_URL", "amqp://guest:guest@localhost:5672/%2F")

--- a/src/nrc/conf/production.py
+++ b/src/nrc/conf/production.py
@@ -8,6 +8,7 @@ and HTTPS is leveraged where possible to further secure things.
 import os
 
 os.environ.setdefault("ENVIRONMENT", "production")
+os.environ.setdefault("DISABLE_2FA", "no")
 
 from .includes.base import *  # noqa
 

--- a/src/nrc/conf/staging.py
+++ b/src/nrc/conf/staging.py
@@ -7,5 +7,6 @@ This *should* be nearly identical to production.
 import os
 
 os.environ.setdefault("ENVIRONMENT", "staging")
+os.environ.setdefault("DISABLE_2FA", "no")
 
 from .production import *  # noqa


### PR DESCRIPTION
Fixes [#1637](https://github.com/open-zaak/open-zaak/issues/1637)

Moved environmental variable to disable 2FA to base.py