### PR TITLE
:wrench: Add missing readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+---
+
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+  - requirements: requirements/dev.txt


### PR DESCRIPTION
The docs build was failing because of this
![image](https://github.com/open-zaak/open-notificaties/assets/29249171/defb5d1f-b24d-4294-96a9-1b6d79159a47)
