### PR TITLE
:wrench: Always use requests.hostname for 2FA app title

### DIFF
--- a/src/nrc/accounts/tests/test_2fa.py
+++ b/src/nrc/accounts/tests/test_2fa.py
@@ -1,0 +1,23 @@
+from django.contrib.sites.models import Site
+from django.test import RequestFactory, TestCase, override_settings
+from django.urls import resolve
+
+
+@override_settings(ALLOWED_HOSTS=["some-domain.local"], DISABLE_2FA=False)
+class TwoFactorQRGeneratorTestCase(TestCase):
+    def test_qr_code_generator_does_not_use_sites_framework(self):
+        """
+        Regression test for https://github.com/maykinmedia/open-api-framework/issues/40
+        Testing the actual QR code output is too much of a hassle, so instead retrieve
+        the view class based on the URL and check if `get_issuer` behaves as expected
+        """
+        site = Site.objects.get_current()
+        site.domain = "testserver"
+        site.save()
+
+        qr_generator_view_class = resolve("/admin/mfa/qrcode/").func.view_class
+        issuer = qr_generator_view_class(
+            request=RequestFactory().get("/", headers={"Host": "some-domain.local"})
+        ).get_issuer()
+
+        self.assertEqual(issuer, "some-domain.local")

--- a/src/nrc/accounts/views.py
+++ b/src/nrc/accounts/views.py
@@ -1,0 +1,8 @@
+from django.contrib.sites.requests import RequestSite
+
+from maykin_2fa.views import QRGeneratorView as _QRGeneratorView
+
+
+class QRGeneratorView(_QRGeneratorView):
+    def get_issuer(self):
+        return RequestSite(self.request).name

--- a/src/nrc/urls.py
+++ b/src/nrc/urls.py
@@ -11,6 +11,8 @@ from maykin_2fa.urls import urlpatterns, webauthn_urlpatterns
 from mozilla_django_oidc_db.views import AdminLoginFailure
 from vng_api_common.views import ViewConfigView
 
+from nrc.accounts.views import QRGeneratorView
+
 handler500 = "nrc.utils.views.server_error"
 
 admin.site.enable_nav_sidebar = False
@@ -21,6 +23,11 @@ monkeypatch_admin()
 urlpatterns = [
     path("admin/login/failure/", AdminLoginFailure.as_view(), name="admin-oidc-error"),
     # 2fa
+    # See https://github.com/maykinmedia/open-api-framework/issues/40
+    # and https://github.com/maykinmedia/open-api-framework/issues/59
+    # Temporary workaround to remove the dependency on `django.contrib.sites` when
+    # generating the app label for 2FA. This should be removed once `sites` are removed
+    path("admin/mfa/qrcode/", QRGeneratorView.as_view(), name="qr"),
     path("admin/", include((urlpatterns, "maykin_2fa"))),
     path("admin/", include((webauthn_urlpatterns, "two_factor"))),
     path("admin/", admin.site.urls),


### PR DESCRIPTION
fixes maykinmedia/open-api-framework#40 partially