### PR TITLE
:memo: Update delivery guarantee documentation

### DIFF
--- a/docs/installation/configuration/opennotifs_config_cli.rst
+++ b/docs/installation/configuration/opennotifs_config_cli.rst
@@ -65,6 +65,8 @@ Make sure that the correct permissions are configured in Open Zaak Autorisaties 
   for example, ``open-zaak``. Required.
 * ``OPENZAAK_NOTIF_SECRET``: some random string. Required.
 
+.. _installation_configuration_cli_retry:
+
 Notification retry configuration
 --------------------------------
 


### PR DESCRIPTION
related to: https://github.com/maykinmedia/objects-api/issues/403
this still used outdated information, the envvars are now only used by setup configuration and the config can be done via the admin