### PR TITLE
Include gettext dependency in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
         procps \
         nano \
         curl \
+        gettext \
         postgresql-client \
         # Required for Celery to work.
         netcat-openbsd \


### PR DESCRIPTION
Apart from translations, this is also needed for the envsubst command, which is used in the Helm charts with which this service is deployed.