### PR TITLE
Feature/180 enable notificatie responses admin

### DIFF
--- a/src/nrc/datamodel/admin.py
+++ b/src/nrc/datamodel/admin.py
@@ -115,9 +115,9 @@ class StatusCodeFilter(admin.SimpleListFilter):
 @admin.register(Abonnement)
 class AbonnementAdmin(admin.ModelAdmin):
     list_display = (
-        "callback_url",
         "uuid",
         "client_id",
+        "callback_url",
         "get_callback_url_reachable",
         "get_kanalen_display",
     )

--- a/src/nrc/datamodel/admin.py
+++ b/src/nrc/datamodel/admin.py
@@ -115,9 +115,9 @@ class StatusCodeFilter(admin.SimpleListFilter):
 @admin.register(Abonnement)
 class AbonnementAdmin(admin.ModelAdmin):
     list_display = (
+        "callback_url",
         "uuid",
         "client_id",
-        "callback_url",
         "get_callback_url_reachable",
         "get_kanalen_display",
     )

--- a/src/nrc/datamodel/models.py
+++ b/src/nrc/datamodel/models.py
@@ -87,7 +87,7 @@ class Abonnement(models.Model):
         verbose_name_plural = _("abonnementen")
 
     def __str__(self) -> str:
-        return f"{self.uuid}"
+        return f"{self.callback_url}"
 
     @property
     def kanalen(self):

--- a/src/nrc/datamodel/models.py
+++ b/src/nrc/datamodel/models.py
@@ -7,6 +7,7 @@ from django.db.models import Max
 from django.utils.translation import gettext_lazy as _
 
 from djangorestframework_camel_case.util import camelize
+from rest_framework.fields import DateTimeField
 
 
 class Kanaal(models.Model):
@@ -152,6 +153,14 @@ class Notificatie(models.Model):
         return (
             self.notificatieresponse_set.aggregate(Max("attempt"))["attempt__max"] or 0
         )
+
+    @property
+    def created_date(self):
+        aanmaakdatum = self.forwarded_msg.get("aanmaakdatum")
+        if not aanmaakdatum:
+            return None
+
+        return DateTimeField().to_internal_value(aanmaakdatum)
 
     def __str__(self) -> str:
         return f"Notificatie ({self.kanaal})"

--- a/src/nrc/datamodel/models.py
+++ b/src/nrc/datamodel/models.py
@@ -88,7 +88,7 @@ class Abonnement(models.Model):
         verbose_name_plural = _("abonnementen")
 
     def __str__(self) -> str:
-        return f"{self.callback_url}"
+        return self.callback_url
 
     @property
     def kanalen(self):

--- a/src/nrc/fixtures/default_admin_index.json
+++ b/src/nrc/fixtures/default_admin_index.json
@@ -65,6 +65,10 @@
             [
                 "datamodel",
                 "notificatie"
+            ],
+            [
+                "datamodel",
+                "notificatieresponse"
             ]
         ]
     }


### PR DESCRIPTION
Fixes: #180 

- Enabled `NotificatieResponseAdmin` in `default_admin_index.json`
- Showing the datetime of the notification in the listview
- Added `raw_id_fields = ["notificatie", "abonnement"]` in `NotificatieResponseAdmin`

![image](https://github.com/user-attachments/assets/13303668-0fb5-49a0-a529-3d213b94c7fa)
