### PR TITLE
:lipstick: [#248] Fix broken tooltip helptexts for datetime fields in admin

### DIFF
--- a/src/nrc/sass/admin/_admin_theme.scss
+++ b/src/nrc/sass/admin/_admin_theme.scss
@@ -189,6 +189,37 @@ div.help {
 }
 
 /**
+ * Help text for datetime field is without inner div
+ */
+ div.help:not(:has(div)) {
+  cursor: help;
+  width: 16px;
+  height: 16px;
+  background-image: url(../../admin/img/icon-unknown.svg);
+  display: inline-block;
+  background-repeat: no-repeat;
+  background-size: 14px;
+  margin-left: 8px !important;
+  margin-top: 6px !important;
+  position: absolute;
+  text-indent: -9999px;
+
+  &:hover {
+    text-indent: inherit;
+    width: auto;
+    background-image: none;
+    background-color: $color-tooltip-background;
+    border: 1px solid $color-tooltip-border;
+    color: $color-tooltip-text;
+    padding: 5px 5px 3px 5px !important;
+    max-width: 300px;
+    height: auto !important;
+    margin-top: 2px !important;
+    z-index: 10;
+  }
+}
+
+/**
  * Help text layout
  */
 .form-row:has(.help) {


### PR DESCRIPTION
Closes #248 

**Changes**

* Fix broken tooltip helptexts for datetime fields in admin

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
