### PR TITLE
:sparkles: Remove django.contrib.sites

### DIFF
--- a/docker/setup_configuration/data.yaml
+++ b/docker/setup_configuration/data.yaml
@@ -136,7 +136,7 @@ sites_config:
   items:
     - domain: example.com
       name: Open Notificaties
-
+      
 notifications_config_enable: true
 notifications_config:
   notifications_api_service_identifier: notificaties-api

--- a/docs/installation/configuration/env_config.rst
+++ b/docs/installation/configuration/env_config.rst
@@ -108,6 +108,7 @@ Optional
 * ``NUM_PROXIES``: the number of reverse proxies in front of the application, as an integer. This is used to determine the actual client IP adres. On Kubernetes with an ingress you typically want to set this to 2. Defaults to: ``1``.
 * ``CSRF_TRUSTED_ORIGINS``: A list of trusted origins for unsafe requests (e.g. POST). Defaults to: ``[]``.
 * ``NOTIFICATIONS_DISABLED``: indicates whether or not notifications should be sent to the Notificaties API for operations on the API endpoints. Defaults to ``True`` for the ``dev`` environment, otherwise defaults to ``False``.
+* ``SITE_DOMAIN``: Defines the primary domain where the application is hosted. Defaults to: ``(empty string)``.
 * ``SENTRY_DSN``: URL of the sentry project to send error reports to. Default empty, i.e. -> no monitoring set up. Highly recommended to configure this.
 * ``DISABLE_2FA``: Whether or not two factor authentication should be disabled. Defaults to: ``False``.
 * ``LOG_OUTGOING_REQUESTS_EMIT_BODY``: Whether or not outgoing request bodies should be logged. Defaults to: ``True``.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -58,7 +58,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
-commonground-api-common==2.5.0
+commonground-api-common==2.5.5
     # via
     #   -r requirements/base.in
     #   open-api-framework
@@ -246,11 +246,11 @@ mozilla-django-oidc-db==0.22.0
     # via
     #   -r requirements/base.in
     #   open-api-framework
-notifications-api-common==0.6.0
+notifications-api-common==0.7.2
     # via
     #   -r requirements/base.in
     #   commonground-api-common
-open-api-framework==0.9.3
+open-api-framework==0.9.6
     # via -r requirements/base.in
 orderedmultidict==1.0.1
     # via furl

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -116,7 +116,7 @@ click-repl==0.3.0
     #   celery
 codecov==2.1.13
     # via -r requirements/test-tools.in
-commonground-api-common==2.5.0
+commonground-api-common==2.5.5
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
@@ -496,12 +496,12 @@ multidict==6.0.5
     # via yarl
 mypy-extensions==0.4.3
     # via black
-notifications-api-common==0.6.0
+notifications-api-common==0.7.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   commonground-api-common
-open-api-framework==0.9.3
+open-api-framework==0.9.6
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -142,7 +142,7 @@ codecov==2.1.13
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-commonground-api-common==2.5.0
+commonground-api-common==2.5.5
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
@@ -582,12 +582,12 @@ mypy-extensions==0.4.3
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   black
-notifications-api-common==0.6.0
+notifications-api-common==0.7.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   commonground-api-common
-open-api-framework==0.9.3
+open-api-framework==0.9.6
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/nrc/conf/includes/api.py
+++ b/src/nrc/conf/includes/api.py
@@ -51,6 +51,8 @@ SPECTACULAR_SETTINGS = {
     "TAGS": [{"name": "abonnement"}, {"name": "kanaal"}, {"name": "notificaties"}],
 }
 
+COMMONGROUND_API_COMMON_GET_DOMAIN = "nrc.utils.get_domain"
+
 GEMMA_URL_INFORMATIEMODEL_VERSIE = "1.0"
 
 TEST_CALLBACK_AUTH = True

--- a/src/nrc/conf/includes/base.py
+++ b/src/nrc/conf/includes/base.py
@@ -12,6 +12,10 @@ from .api import *  # noqa
 # APPLICATIONS enabled for this project
 #
 INSTALLED_APPS = INSTALLED_APPS + [
+    # `django.contrib.sites` added at the project level because it has been removed at the packages level.
+    # This component is deprecated and should be completely removed.
+    # To determine the project's domain, use the `SITE_DOMAIN` environment variable.
+    "django.contrib.sites",
     # External applications.
     "vng_api_common.authorizations",
     "vng_api_common.notifications",
@@ -181,3 +185,5 @@ config(
         "``EXTRA_VERIFY_CERTS=/etc/ssl/root1.crt,/etc/ssl/root2.crt``."
     ),
 )
+
+NOTIFICATIONS_API_GET_DOMAIN = "nrc.utils.get_domain"

--- a/src/nrc/fixtures/default_admin_index.json
+++ b/src/nrc/fixtures/default_admin_index.json
@@ -107,6 +107,10 @@
             [
                 "log_outgoing_requests",
                 "outgoingrequestslogconfig"
+            ],
+            [
+                "sites",
+                "site"
             ]
         ]
     }

--- a/src/nrc/tests/test_view_config.py
+++ b/src/nrc/tests/test_view_config.py
@@ -1,0 +1,33 @@
+from django.test import override_settings
+from django.urls import reverse_lazy
+
+from django_webtest import WebTest
+
+
+class ViewConfigTestCase(WebTest):
+    url = reverse_lazy("view-config")
+    api_root = "http://notifications.local/api/v1/"
+
+    def test_get_domain(self):
+        """
+        SITE_DOMAIN > django.contrib.sites
+        """
+        from django.contrib.sites.models import Site
+
+        site = Site.objects.get_current()
+        site.domain = "testserver.nl"
+        site.save()
+
+        with self.subTest("domain_from_DJANGO_SITES"):
+            with override_settings(SITE_DOMAIN=""):
+                response = self.app.get(self.url)
+                self.assertEqual(response.status_code, 200)
+                rows = response.html.findAll("tr")
+                self.assertTrue("testserver.nl" in rows[1].text)
+
+        with self.subTest("domain_from_SITE_DOMAIN"):
+            with override_settings(SITE_DOMAIN="site.nl"):
+                response = self.app.get(self.url)
+                self.assertEqual(response.status_code, 200)
+                rows = response.html.findAll("tr")
+                self.assertTrue("site.nl" in rows[1].text)

--- a/src/nrc/utils/__init__.py
+++ b/src/nrc/utils/__init__.py
@@ -1,0 +1,20 @@
+import warnings
+
+from django.conf import settings
+
+
+def get_domain() -> str:
+    """
+    Obtain the domain of Open Notificaties according to settings or configuration.
+    """
+    from django.contrib.sites.models import Site
+
+    if settings.SITE_DOMAIN:
+        return settings.SITE_DOMAIN
+
+    warnings.warn(
+        "Deriving the domain from the `Sites` configuration will soon be deprecated, "
+        "please migrate to the SITE_DOMAIN setting.",
+        PendingDeprecationWarning,
+    )
+    return Site.objects.get_current().domain


### PR DESCRIPTION
Partially fixed https://github.com/maykinmedia/open-api-framework/issues/59

- [x] Upgrade open-api-framework==0.9.6
- [x] Upgrade notifications-api-common==0.7.2
- [x] Upgrade commonground-api-common==2.5.5
- [x] Check docs
- [x] Delete django_setup_configuration for site
- [x] Remove from INSTALLED_APPS 
- [x] Remove from Admin
- [x] Revert QRGeneratorView, tests and url