### PR TITLE
:bug: [#258] Make notifications_api_service_identifier optional

### DIFF
--- a/docker/setup_configuration/data.yaml
+++ b/docker/setup_configuration/data.yaml
@@ -136,7 +136,7 @@ sites_config:
   items:
     - domain: example.com
       name: Open Notificaties
-      
+
 notifications_config_enable: true
 notifications_config:
   notifications_api_service_identifier: notificaties-api

--- a/docs/delivery_guarantees.rst
+++ b/docs/delivery_guarantees.rst
@@ -79,7 +79,7 @@ the formula to calculate the time to wait until the next retry is as follows:
 
 where `t` is time in seconds and  `c` is the number of retries that have been performed already.
 
-This behaviour can be configured using :ref:`setup_configuration <ref_step_notifications_api_common.contrib.setup_configuration.steps.NotificationConfigurationStep>`
+This behaviour can be configured using :ref:`setup_configuration <ref_step_nrc.setup_configuration.steps.NotificationConfigurationStep>`
 and also via the admin interface at **Configuratie > Notificatiescomponentconfiguratie**:
 
 * **Notification delivery max retries**: the maximum number of retries the task queue

--- a/src/nrc/conf/includes/base.py
+++ b/src/nrc/conf/includes/base.py
@@ -173,7 +173,7 @@ SETUP_CONFIGURATION_STEPS = [
     "nrc.setup_configuration.authorization.AuthorizationStep",
     "vng_api_common.contrib.setup_configuration.steps.JWTSecretsConfigurationStep",
     "nrc.setup_configuration.kanalen.KanaalConfigurationStep",
-    "notifications_api_common.contrib.setup_configuration.steps.NotificationConfigurationStep",
+    "nrc.setup_configuration.steps.NotificationConfigurationStep",
     "notifications_api_common.contrib.setup_configuration.steps.NotificationSubscriptionConfigurationStep",
     "nrc.setup_configuration.abonnementen.AbonnementConfigurationStep",
     "django_setup_configuration.contrib.sites.steps.SitesConfigurationStep",

--- a/src/nrc/setup_configuration/models.py
+++ b/src/nrc/setup_configuration/models.py
@@ -1,5 +1,10 @@
+from typing import Optional
+
 from django_setup_configuration.fields import DjangoModelRef
 from django_setup_configuration.models import ConfigurationModel
+from notifications_api_common.contrib.setup_configuration.models import (
+    NotificationConfigurationModel as _NotificationConfigurationModel,
+)
 from pydantic import UUID4, Field
 from vng_api_common.authorizations.models import AuthorizationsConfig
 
@@ -81,3 +86,12 @@ class AbonnementConfigurationItem(ConfigurationModel):
 
 class AbonnementConfigurationModel(ConfigurationModel):
     items: list[AbonnementConfigurationItem]
+
+
+class NotificationConfigurationModel(_NotificationConfigurationModel):
+    notifications_api_service_identifier: Optional[str] = Field(
+        default=None, examples=["notificaties-api"]
+    )
+
+    class Meta(_NotificationConfigurationModel.Meta):
+        pass

--- a/src/nrc/setup_configuration/steps.py
+++ b/src/nrc/setup_configuration/steps.py
@@ -1,0 +1,9 @@
+from notifications_api_common.contrib.setup_configuration.steps import (
+    NotificationConfigurationStep as _NotificationConfigurationStep,
+)
+
+from nrc.setup_configuration.models import NotificationConfigurationModel
+
+
+class NotificationConfigurationStep(_NotificationConfigurationStep):
+    config_model = NotificationConfigurationModel

--- a/src/nrc/tests/setup_configuration/files/notifications_config_with_service_identifier.yaml
+++ b/src/nrc/tests/setup_configuration/files/notifications_config_with_service_identifier.yaml
@@ -1,0 +1,6 @@
+notifications_config_enable: true
+notifications_config:
+  notification_delivery_max_retries: 4
+  notification_delivery_retry_backoff: 1
+  notification_delivery_retry_backoff_max: 10
+  notifications_api_service_identifier: notificaties-api

--- a/src/nrc/tests/setup_configuration/files/notifications_config_without_service_identifier.yaml
+++ b/src/nrc/tests/setup_configuration/files/notifications_config_without_service_identifier.yaml
@@ -1,0 +1,5 @@
+notifications_config_enable: true
+notifications_config:
+  notification_delivery_max_retries: 5
+  notification_delivery_retry_backoff: 2
+  notification_delivery_retry_backoff_max: 20

--- a/src/nrc/tests/setup_configuration/test_notification_configuration.py
+++ b/src/nrc/tests/setup_configuration/test_notification_configuration.py
@@ -1,0 +1,37 @@
+from django.test import TestCase
+
+from django_setup_configuration.test_utils import execute_single_step
+from notifications_api_common.models import NotificationsConfig
+from zgw_consumers.models import Service
+
+from nrc.setup_configuration.steps import NotificationConfigurationStep
+
+
+class NotificationConfigurationTest(TestCase):
+    def test_notifications_api_service_identifier_is_optional(self):
+        config_file_path = (
+            "src/nrc/tests/setup_configuration/files/"
+            "notifications_config_without_service_identifier.yaml"
+        )
+        execute_single_step(NotificationConfigurationStep, yaml_source=config_file_path)
+        config = NotificationsConfig.get_solo()
+        assert config.notification_delivery_max_retries == 5
+        assert config.notification_delivery_retry_backoff == 2
+        assert config.notification_delivery_retry_backoff_max == 20
+
+        assert config.notifications_api_service is None
+
+    def test_notifications_api_service_identifier_is_saved(self):
+        Service.objects.create(
+            label="Notificaties API",
+            api_root="https://example.com/api/v1/",
+            slug="notificaties-api",
+        )
+
+        config_file_path = "src/nrc/tests/setup_configuration/files/notifications_config_with_service_identifier.yaml"
+        execute_single_step(NotificationConfigurationStep, yaml_source=config_file_path)
+        config = NotificationsConfig.get_solo()
+        assert config.notification_delivery_max_retries == 4
+        assert config.notification_delivery_retry_backoff == 1
+        assert config.notification_delivery_retry_backoff_max == 10
+        assert config.notifications_api_service.slug == "notificaties-api"


### PR DESCRIPTION
Closes #258 
