### PR TITLE
:arrow_up: Upgrade notifications-api-common to 0.8.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -254,7 +254,7 @@ mozilla-django-oidc-db==0.22.0
     # via
     #   -r requirements/base.in
     #   open-api-framework
-notifications-api-common==0.7.3
+notifications-api-common==0.8.0
     # via
     #   -r requirements/base.in
     #   commonground-api-common

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -495,7 +495,7 @@ mozilla-django-oidc-db==0.22.0
     #   open-api-framework
 multidict==6.0.5
     # via yarl
-notifications-api-common==0.7.3
+notifications-api-common==0.8.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -576,7 +576,7 @@ multidict==6.0.5
     #   yarl
 nodeenv==1.9.1
     # via pre-commit
-notifications-api-common==0.7.3
+notifications-api-common==0.8.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/nrc/api/tests/test_notificatie.py
+++ b/src/nrc/api/tests/test_notificatie.py
@@ -594,6 +594,7 @@ class NotificatieRetryTests(TestCase):
             factor=4,
             retries=0,
             maximum=28,
+            base=4,
             full_jitter=False,
         )
         self.assertEqual(deliver_message.max_retries, 4)


### PR DESCRIPTION
for the configurable base factor for retry settings

Closes #290 

**Changes**

* Upgrade notifications-api-common to 0.8.0

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
