### PR TITLE
:memo: Fix incorrect default in docs for DB_CONN_MAX_AGE

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
       DJANGO_SUPERUSER_PASSWORD: admin
       DISABLE_2FA: ${DISABLE_2FA:-yes}
       LOG_NOTIFICATIONS_IN_DB: ${LOG_NOTIFICATIONS_IN_DB:-yes}
+      DB_CONN_MAX_AGE: "0"
+      DB_POOL_ENABLED: True
     healthcheck:
       test: ["CMD", "python", "-c", "import requests; exit(requests.head('http://localhost:8000/admin/').status_code not in [200, 302])"]
       interval: 30s

--- a/docs/installation/configuration/env_config.rst
+++ b/docs/installation/configuration/env_config.rst
@@ -32,8 +32,8 @@ Database
 * ``DB_PASSWORD``: password of the database user. Defaults to: ``nrc``.
 * ``DB_HOST``: hostname of the PostgreSQL database. Defaults to ``db`` for the docker environment, otherwise defaults to ``localhost``.
 * ``DB_PORT``: port number of the database. Defaults to: ``5432``.
-* ``DB_CONN_MAX_AGE``: The lifetime of a database connection, as an integer of seconds. Use 0 to close database connections at the end of each request — Django’s historical behavior. This setting cannot be set in combination with connection pooling. Defaults to: ``0``.
-* ``DB_POOL_ENABLED``: Whether to use connection pooling. Defaults to: ``False``.
+* ``DB_CONN_MAX_AGE``: The lifetime of a database connection, as an integer of seconds. Use 0 to close database connections at the end of each request — Django’s historical behavior. This setting must be set to 0 if connection pooling is used. Defaults to: ``60``.
+* ``DB_POOL_ENABLED``: Whether to use connection pooling (requires ``DB_CONN_MAX_AGE`` to be set to 0). Defaults to: ``False``.
 * ``DB_POOL_MIN_SIZE``: The minimum number of connection the pool will hold. The pool will actively try to create new connections if some are lost (closed, broken) and will try to never go below min_size. Defaults to: ``4``.
 * ``DB_POOL_MAX_SIZE``: The maximum number of connections the pool will hold. If None, or equal to min_size, the pool will not grow or shrink. If larger than min_size, the pool can grow if more than min_size connections are requested at the same time and will shrink back after the extra connections have been unused for more than max_idle seconds. Defaults to: ``None``.
 * ``DB_POOL_TIMEOUT``: The default maximum time in seconds that a client can wait to receive a connection from the pool (using connection() or getconn()). Note that these methods allow to override the timeout default. Defaults to: ``30``.

--- a/src/nrc/conf/docker.py
+++ b/src/nrc/conf/docker.py
@@ -4,6 +4,7 @@ os.environ.setdefault("DB_HOST", "db")
 os.environ.setdefault("DB_NAME", "postgres")
 os.environ.setdefault("DB_USER", "postgres")
 os.environ.setdefault("DB_PASSWORD", "")
+os.environ.setdefault("DB_CONN_MAX_AGE", "60")
 
 os.environ.setdefault("ENVIRONMENT", "docker")
 os.environ.setdefault("LOG_STDOUT", "yes")

--- a/src/nrc/conf/includes/base.py
+++ b/src/nrc/conf/includes/base.py
@@ -14,12 +14,16 @@ from .api import *  # noqa
 DATABASES["default"]["CONN_MAX_AGE"] = config(
     "DB_CONN_MAX_AGE",
     default=0,
+    # The default is set to `60` in the docker settings, so that's what is mentioned
+    # in the help text as well
     help_text=(
         "The lifetime of a database connection, as an integer of seconds. "
         "Use 0 to close database connections at the end of each request — Django’s historical behavior. "
-        "This setting cannot be set in combination with connection pooling."
+        "This setting must be set to 0 if connection pooling is used. Defaults to: ``60``."
     ),
     group="Database",
+    auto_display_default=False,
+    cast=lambda x: int(x) if x != "None" else None,
 )
 
 
@@ -29,7 +33,10 @@ DATABASES["default"]["CONN_MAX_AGE"] = config(
 DB_POOL_ENABLED = config(
     "DB_POOL_ENABLED",
     default=False,
-    help_text=("Whether to use connection pooling."),
+    help_text=(
+        "Whether to use connection pooling "
+        "(requires ``DB_CONN_MAX_AGE`` to be set to 0)."
+    ),
     group="Database",
 )
 


### PR DESCRIPTION
**Changes**

* Fix incorrect default in docs for DB_CONN_MAX_AGE

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
