### PR TITLE
:wrench: [#313] add rabbitmq consumer_timeout config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
 
   rabbitmq:
     image: rabbitmq:4.0-alpine
+    volumes:
+      - ./docker/rabbitmq/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
     networks:
       - open-notificaties-dev
 

--- a/docker/rabbitmq/rabbitmq.conf
+++ b/docker/rabbitmq/rabbitmq.conf
@@ -1,0 +1,1 @@
+consumer_timeout = 86400000  # 1 day in milliseconds


### PR DESCRIPTION
Closes #313

**Changes**

Added config to set the rabbitmq consumer timeout to 1 day

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
