### PR TITLE
:arrow_up: Upgrade zgw-consumers to 1.1.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -476,7 +476,7 @@ wrapt==1.16.0
     # via
     #   elastic-apm
     #   opentelemetry-instrumentation
-zgw-consumers==1.1.1
+zgw-consumers==1.1.2
     # via
     #   -r requirements/base.in
     #   commonground-api-common

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -923,7 +923,7 @@ wrapt==1.16.0
     #   vcrpy
 yarl==1.9.4
     # via vcrpy
-zgw-consumers==1.1.1
+zgw-consumers==1.1.2
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1113,7 +1113,7 @@ yarl==1.9.4
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   vcrpy
-zgw-consumers==1.1.1
+zgw-consumers==1.1.2
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
to avoid 500 errors when configuring Services with oauth2 config that is incorrect

**Changes**

* Upgrade zgw-consumers to 1.1.2

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
