### PR TITLE
:memo: [#373] Improve MijnOverheid config docs + add setupconfig example

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,7 @@ extensions = [
     "sphinx_markdown_tables",
     "django_setup_configuration.documentation.setup_config_example",
     "django_setup_configuration.documentation.setup_config_usage",
+    "django_setup_configuration.documentation.validate_config_example",
     "vng_api_common.diagrams.uml_images",
 ]
 

--- a/docs/installation/configuration/cloud_events_mijn_overheid.rst
+++ b/docs/installation/configuration/cloud_events_mijn_overheid.rst
@@ -7,20 +7,55 @@ Configuring cloud events for Mijn Overheid
 Open Notificaties has experimental support for sending cloud events to subscribed webhooks.
 
 This can be used to send cloud events to Mijn Overheid. In order to make this possible, some
-configuration is required.
+configuration is required, which can be done manually or loaded using :ref:`setup_configuration <installation_configuration_cli>`.
+
+Using ``setup_configuration``
+-----------------------------
+
+For ``setup_configuration``, a configuration similar to this could be used
+(see the related configuration step
+:ref:`documentation <ref_step_nrc.setup_configuration.abonnementen.AbonnementConfigurationStep>` for more details):
+
+.. validate-config-example:: nrc.setup_configuration.abonnementen.AbonnementConfigurationStep
+
+    notifications_abonnementen_config_enable: true
+    notifications_abonnementen_config:
+      items:
+        - uuid: 02907e89-1ba8-43e9-a86c-d0534d461316  # Some generated UUID
+          callback_url: https://example.com/api/webhook/  # the URL of the API of Mijn Overheid
+          cloudevent_filters:
+            # Filter on a specific zaaktype for the ``zaak-gemuteerd`` event
+            # Repeat if needed for multiple zaaktypen
+            - filters:
+                zaaktype: https://openzaak.local/catalogi/api/v1/zaaktypen/d109cd8a-fe7b-4eb2-8cab-766712a4a267
+              type_substring: nl.overheid.zaken.zaak-gemuteerd
+          auth_type: oauth2_client_credentials
+          auth_client_id: client-id  # client id as received from Logius
+          secret: my-secret
+          oauth2_token_url: https://auth.example.com/token
+          send_cloudevents: true
+
+If mutual TLS is required, the certificates for that have to be configured manually (see below),
+as this is not possible via ``setup_configuration`` at the moment.
+
+.. TODO::
+
+    Ensure that certificates for mutual TLS can also be loaded using ``setup_configuration``
+
+Manual configuration
+--------------------
 
 1. Make sure that PKIOverheid root certificate is added via the environment variable
    ``EXTRA_VERIFY_CERTS`` (see :ref:`installation_self_signed` for more information)
 2. In the admin interface, navigate to **Notificaties > Abonnementen** and click **Abonnement toevoegen**.
 3. Fill out the following fields
 
-    * ``Label``: e.g.: ``Mijn Overheid``
     * ``Callback URL``: enter the URL of the API of Mijn Overheid
     * ``Authorization type``: select ``OAuth2 client credentials flow``
     * ``Client id``: enter the client id as received from Logius
     * ``Secret``: enter the secret as received from Logius
     * ``OAuth2 token url``: enter the URL of the Logius authentication server token endpoint
-    * (Optional if mutual TLS is required): ``Client certificate`` click the ``+`` icon:
+    * (If mutual TLS is required): ``Client certificate`` click the ``+`` icon:
 
         * ``Label``: e.g. ``client certificate for Logius``
         * ``Type``: ``Key-pair``
@@ -32,6 +67,8 @@ configuration is required.
         * ``Label``: e.g. ``PKIOverheid root certificate``
         * ``Type``: ``Certificate only``
         * ``Public certificate``: upload the PKIOverheid root certificate
+
+    * Check the checkbox ``Verstuur cloudevents``
 
     * Under **Cloud event filter groups**, add an entry with:
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -160,7 +160,7 @@ django-sendfile2==0.7.1
     # via django-privates
 django-sessionprofile==3.0.0
     # via open-api-framework
-django-setup-configuration==0.11.0
+django-setup-configuration==0.12.0
     # via
     #   -r requirements/base.in
     #   mozilla-django-oidc-db

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -278,7 +278,7 @@ django-sessionprofile==3.0.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   open-api-framework
-django-setup-configuration==0.11.0
+django-setup-configuration==0.12.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -320,7 +320,7 @@ django-sessionprofile==3.0.0
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
     #   open-api-framework
-django-setup-configuration==0.11.0
+django-setup-configuration==0.12.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Closes #373

Requires https://github.com/maykinmedia/django-setup-configuration/pull/93 to be merged/released

**Changes**

* Fix minor mistakes in MijnOverheid config docs and add a setup_configuration example for it

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
