### PR TITLE
:lipstick: Do not show version information on dashboard

### DIFF
--- a/src/nrc/utils/context_processors.py
+++ b/src/nrc/utils/context_processors.py
@@ -9,8 +9,6 @@ def settings(request):
         "PROJECT_NAME",
         "SITE_TITLE",
         "API_VERSION",
-        "GIT_SHA",
-        "RELEASE",
     )
 
     return {"settings": {k: getattr(django_settings, k, None) for k in public_settings}}


### PR DESCRIPTION
previously this was visible without being logged in

**Changes**

Do not show version information on dashboard

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
