### PR TITLE
:memo: Slightly clarify celery beat warning in changelog for 1.16.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,9 @@ Changes
 
 .. warning::
 
-  This release drops RabbitMQ as a dependency and relies on Celery Beat (which was already
-  a dependency) and database persisted schedules to send notifications. RabbitMQ is no longer needed and can be removed
+  This release drops RabbitMQ as a dependency and relies on a container/pod running Celery Beat (which was already
+  a dependency) and database persisted schedules to send notifications. Celery beat can be run
+  using the ``./bin/celery_beat.sh`` command. RabbitMQ is no longer needed and can be removed
   from deployment. If you do, it's important to make sure that ``CELERY_BROKER_URL`` and ``CELERY_RESULT_BACKEND``
   point to Redis instead.
 

--- a/docs/delivery_guarantees.rst
+++ b/docs/delivery_guarantees.rst
@@ -28,7 +28,8 @@ Flow
 
 After a notification (or cloudevent) is received via the API, all subscriptions that need to receive it are fetched
 and a ScheduledNotification is created in the database for each subscription.
-A background task that runs every ``NOTIFICATION_SEC_INTERVAL`` seconds picks up ``NOTIFICATION_LIMIT``
+A container/pod running Celery Beat (with the ``./bin/celery_beat.sh`` command) runs a
+background task that runs every ``NOTIFICATION_SEC_INTERVAL`` seconds picks up ``NOTIFICATION_LIMIT``
 (see :ref:`installation_env_config` > Celery) of scheduled notifications and creates tasks that will send the
 notification to the subscription callback_urls. Successful ScheduledNotifications are removed,
 failed ones get updated with an ``execute_after`` timestamp to be retried (according to exponential backoff)


### PR DESCRIPTION
**Changes**

Slightly clarify celery beat warning in changelog for 1.16.0

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how
