### PR TITLE
:zap: refactor result queries

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
   apt_packages:

--- a/src/nrc/datamodel/admin.py
+++ b/src/nrc/datamodel/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin, messages
-from django.db.models import Count, OuterRef, Q, Subquery
+from django.db.models import Count, Exists, OuterRef, Q, Subquery
 from django.http import HttpResponseRedirect
 from django.urls import path, reverse
 from django.utils.safestring import mark_safe
@@ -311,25 +311,19 @@ class NotificatieAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
+
         latest_attempts = (
-            NotificatieResponse.objects.filter(notificatie=OuterRef(OuterRef("pk")))
+            NotificatieResponse.objects.filter(
+                notificatie=OuterRef("pk"),
+            )
             .order_by("abonnement", "-attempt")
             .distinct("abonnement")
             .values("pk")
-        )
-
-        failed_attempts = (
-            NotificatieResponse.objects.filter(pk__in=Subquery(latest_attempts))
             .filter(Q(response_status__lt=200) | Q(response_status__gte=300))
-            .values("pk")
         )
 
-        qs = qs.annotate(
-            failed_responses_count=Count(
-                "notificatieresponse",
-                filter=Q(notificatieresponse__pk__in=Subquery(failed_attempts)),
-            ),
-        )
+        qs = qs.annotate(has_failure=Exists(latest_attempts))
+
         return qs
 
     @admin.display(
@@ -337,7 +331,7 @@ class NotificatieAdmin(admin.ModelAdmin):
         boolean=True,
     )
     def result(self, obj):
-        return obj.failed_responses_count == 0
+        return not obj.has_failure
 
     @admin.display(description=_("Action"))
     def action(self, obj):

--- a/src/nrc/datamodel/admin_filters.py
+++ b/src/nrc/datamodel/admin_filters.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from django.db.models import Count, Q
 from django.utils.translation import gettext_lazy as _
 
 
@@ -52,13 +51,7 @@ class ResultFilter(admin.SimpleListFilter):
         if not self.value():
             return queryset
 
-        annotated = queryset.annotate(
-            num_responses=Count(
-                "notificatieresponse",
-                filter=~Q(notificatieresponse__response_status=204),
-            )
-        )
         if self.value() == "success":
-            return annotated.filter(num_responses=0)
+            return queryset.filter(has_failure=False)
         elif self.value() == "failure":
-            return annotated.filter(num_responses__gte=1)
+            return queryset.filter(has_failure=True)

--- a/src/nrc/datamodel/tests/test_filter.py
+++ b/src/nrc/datamodel/tests/test_filter.py
@@ -1,0 +1,116 @@
+from django.contrib.admin.sites import AdminSite
+from django.test import RequestFactory, TestCase
+
+from ..admin import NotificatieAdmin
+from ..admin_filters import ResultFilter
+from ..models import Notificatie
+from .factories import (
+    AbonnementFactory,
+    NotificatieFactory,
+    NotificatieResponseFactory,
+)
+
+
+class NotificatieFilterTests(TestCase):
+    def setUp(self):
+        self.site = AdminSite()
+        self.admin = NotificatieAdmin(Notificatie, self.site)
+        self.factory = RequestFactory()
+
+    def test_get_queryset_notification_without_failures(self):
+        notificatie = NotificatieFactory.create()
+        abonnement = AbonnementFactory.create()
+
+        NotificatieResponseFactory.create(
+            notificatie=notificatie,
+            abonnement=abonnement,
+            attempt=1,
+            response_status=201,
+        )
+
+        request = self.factory.get("/")
+        obj = self.admin.get_queryset(request).get(pk=notificatie.pk)
+
+        self.assertFalse(obj.has_failure)
+        self.assertTrue(self.admin.result(obj))
+
+    def test_get_queryset_notification_with_failures(self):
+        notificatie = NotificatieFactory.create()
+        abonnement = AbonnementFactory.create()
+
+        NotificatieResponseFactory.create(
+            notificatie=notificatie,
+            abonnement=abonnement,
+            attempt=1,
+            response_status=500,
+        )
+
+        request = self.factory.get("/")
+        obj = self.admin.get_queryset(request).get(pk=notificatie.pk)
+
+        self.assertTrue(obj.has_failure)
+        self.assertFalse(self.admin.result(obj))
+
+    def test_has_failure_annotation(self):
+        success = NotificatieFactory.create()
+        failure = NotificatieFactory.create()
+
+        abonnement = AbonnementFactory.create()
+
+        NotificatieResponseFactory.create(
+            notificatie=success,
+            abonnement=abonnement,
+            response_status=201,
+        )
+        NotificatieResponseFactory.create(
+            notificatie=failure,
+            abonnement=abonnement,
+            response_status=500,
+        )
+
+        request = self.factory.get("/", {"result": "failure"})
+        request.GET = request.GET.copy()
+
+        qs = self.admin.get_queryset(request)
+
+        filtered = ResultFilter(
+            request,
+            request.GET,
+            Notificatie,
+            self.admin,
+        ).queryset(request, qs)
+
+        self.assertIn(failure, filtered)
+        self.assertNotIn(success, filtered)
+
+    def test_has_succes_annotation(self):
+        success = NotificatieFactory.create()
+        failure = NotificatieFactory.create()
+
+        abonnement = AbonnementFactory.create()
+
+        NotificatieResponseFactory.create(
+            notificatie=success,
+            abonnement=abonnement,
+            response_status=201,
+        )
+        NotificatieResponseFactory.create(
+            notificatie=failure,
+            abonnement=abonnement,
+            response_status=500,
+        )
+
+        request = self.factory.get("/", {"result": "success"})
+        request.GET = request.GET.copy()
+
+        qs = self.admin.get_queryset(request)
+
+        filtered = ResultFilter(
+            request,
+            request.GET,
+            Notificatie,
+            self.admin,
+        ).queryset(request, qs)
+
+        self.assertIn(success, filtered)
+        self.assertNotIn(failure, filtered)


### PR DESCRIPTION
Closes #261 

**Changes**

Updated admin queryset 
Removed the Count an changed with an Exists to see if there are failures.  

Fixed the filters
Will only show result green if all responses are 2xx.

Needed to upgrade the rtd build os, got the following error: https://app.readthedocs.org/projects/open-notificaties/builds/33179224/

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [x] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-notificaties/wiki/Architectural-Decision-Records-(ADR))
