### PR TITLE
:green_heart: [maykinmedia/open-api-framework#218] Upgrade open-api-workflows in CI to v6.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         id: image-name
 
   open-api-ci:
-    uses: maykinmedia/open-api-workflows/.github/workflows/ci.yml@79102b911003d75203ca2fed7df01ad79d9b6bba  # v6.4.0
+    uses: maykinmedia/open-api-workflows/.github/workflows/ci.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
     needs:
       - store-reusable-workflow-vars
     permissions:
@@ -106,7 +106,7 @@ jobs:
       django-settings-module: nrc.conf.ci
 
   open-api-publish:
-    uses: maykinmedia/open-api-workflows/.github/workflows/publish.yml@79102b911003d75203ca2fed7df01ad79d9b6bba  # v6.4.0
+    uses: maykinmedia/open-api-workflows/.github/workflows/publish.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
     needs:
       - store-reusable-workflow-vars
       - open-api-ci

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   open-api-workflow-code-quality:
-    uses: maykinmedia/open-api-workflows/.github/workflows/code-quality.yml@79102b911003d75203ca2fed7df01ad79d9b6bba  # v6.4.0
+    uses: maykinmedia/open-api-workflows/.github/workflows/code-quality.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
     with:
       python-version: '3.12'
       node-version: '24'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,4 +21,4 @@ permissions:
 
 jobs:
   open-api-workflow-code-analysis:
-    uses: maykinmedia/open-api-workflows/.github/workflows/code-analysis.yml@79102b911003d75203ca2fed7df01ad79d9b6bba  # v6.4.0
+    uses: maykinmedia/open-api-workflows/.github/workflows/code-analysis.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1

--- a/.github/workflows/oaf-check.yml
+++ b/.github/workflows/oaf-check.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   open-api-workflow-check-oas:
-    uses: maykinmedia/open-api-workflows/.github/workflows/oaf-check.yml@79102b911003d75203ca2fed7df01ad79d9b6bba  # v6.4.0
+    uses: maykinmedia/open-api-workflows/.github/workflows/oaf-check.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
 
     with:
       python-version: '3.12'

--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   oas:
     name: Checks
-    uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@79102b911003d75203ca2fed7df01ad79d9b6bba  # v6.4.0
+    uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
     with:
       python-version: '3.12'
       apt-packages: 'libgdal-dev gdal-bin'

--- a/.github/workflows/quick-start.yml
+++ b/.github/workflows/quick-start.yml
@@ -15,4 +15,4 @@ permissions:
 
 jobs:
   open-api-workflow-quick-start:
-    uses: maykinmedia/open-api-workflows/.github/workflows/quick-start.yml@79102b911003d75203ca2fed7df01ad79d9b6bba  # v6.4.0
+    uses: maykinmedia/open-api-workflows/.github/workflows/quick-start.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1


### PR DESCRIPTION
Closes maykinmedia/open-api-framework#218 partially

this includes the new version of maykinmedia/setup-django-backend, which contains fixes for the additional security measures in this github org

**Changes**

[Describe the changes here]

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [x] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-notificaties/wiki/Architectural-Decision-Records-(ADR))
