### PR TITLE
:memo: [#390] Add Consumer API description for cloud events

### DIFF
--- a/bin/validate_schema.sh
+++ b/bin/validate_schema.sh
@@ -9,3 +9,9 @@ docker run --rm \
     -w /project \
     usabillabv/openapi3-validator \
     src/openapi.yaml
+
+docker run --rm \
+    -v $(pwd):/project \
+    -w /project \
+    usabillabv/openapi3-validator \
+    src/consumer-openapi.yaml

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -20,19 +20,27 @@ API                     Specification version(s)
 `Notificaties API`_     `1.0 <https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-zaak/open-notificaties/1.0.0/src/openapi.yaml>`__
 ======================  ==========================================
 
-.. _`Notificaties API`: https://vng-realisatie.github.io/gemma-zaken/standaard/notificaties/
+Consumer webhook API specifications
+===================================
 
+Examples of how consumer webhooks should be implemented to receive notifications or cloud events from
+Open Notificaties are documented `here`_ (see also in `ReDoc`_).
+
+.. _`Notificaties API`: https://vng-realisatie.github.io/gemma-zaken/standaard/notificaties/
+.. _`here`:
+   https://github.com/open-zaak/open-notificaties/blob/main/src/consumer-openapi.yaml
+.. _`ReDoc`: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-zaak/open-notificaties/main/src/consumer-openapi.yaml
 
 Deviation from the standards
 ----------------------------
- 
+
 While Open Notificaties supports above mentioned standard it also provides extra features, which can enrich
 the client experience. The full list of them is documented :ref:`here <api_experimental>`.
- 
+
 Reference
 ---------
 
 .. toctree::
    :maxdepth: 1
-   
+
    experimental

--- a/docs/installation/configuration/opennotifs_config.rst
+++ b/docs/installation/configuration/opennotifs_config.rst
@@ -94,7 +94,14 @@ Add notification consumers
 
 In order to add new consumer webhooks that are subscribed to specific channels, follow these steps:
 
-1. Ensure your consumer webhook can handle the notification body (see `API specification`_)
+1. Ensure your consumer webhook can handle the notification body.
+
+   See the following specifications:
+
+   - `API specification`_ for the Open Notificaties API.
+   - `Consumer API specification`_ to view the example consumer webhook API in ReDoc.
+   - `Consumer API specification (GitHub)`_ for the OpenAPI document.
+
 2. Ensure your consumer webhook responds to notifications with a status code in the range 200-209
 3. (Optional) If no **Kanaal** exists for the resource, create it via the admin interface
 
@@ -124,3 +131,7 @@ All done!
 .. _`configuration of Open Zaak`: https://open-zaak.readthedocs.io/en/stable/installation/config/openzaak_config_cli.html#open-zaak-configuration-cli
 .. _`manual`: https://open-notificaties.readthedocs.io/en/stable/manual/subscriptions.html#aanmaken-abonnement
 .. _`API specification`: https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-zaak/open-notificaties/1.0.0/src/openapi.yaml#tag/notificaties
+.. _`Consumer API specification`:
+   https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-zaak/open-notificaties/main/src/consumer-openapi.yaml
+.. _`Consumer API specification (GitHub)`:
+   https://github.com/open-zaak/open-notificaties/blob/main/src/consumer-openapi.yaml

--- a/src/consumer-openapi.yaml
+++ b/src/consumer-openapi.yaml
@@ -1,0 +1,159 @@
+openapi: 3.0.3
+
+info:
+  title: Open Notificaties Consumer API
+  version: 1.0.0
+  description: |
+    Example webhook endpoints that consumers can implement to receive
+    notifications and cloud events from Open Notificaties.
+
+paths:
+  /notifications:
+    post:
+      operationId: receiveNotification
+      summary: Receive a notification
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Message'
+            example:
+              kanaal: autorisaties
+              source: autorisaties.maykin.nl
+              hoofdObject: https://example.com/api/v1/applicaties/123
+              resource: applicatie
+              resourceUrl: https://example.com/api/v1/applicaties/123
+              actie: create
+              aanmaakdatum: "2012-01-14T00:00:00Z"
+              kenmerken: {}
+      responses:
+        "204":
+          description: The notification was successfully received.
+
+  /cloudevents:
+    post:
+      operationId: receiveCloudEvent
+      summary: Receive a CloudEvent
+      requestBody:
+        required: true
+        content:
+          application/cloudevents+json:
+            schema:
+              $ref: '#/components/schemas/CloudEvent'
+            example:
+              specversion: "1.0"
+              type: nl.overheid.zaken.zaak.created
+              source: https://openzaak.example.com
+              subject: 123e4567-e89b-12d3-a456-426614174000
+              id: 550e8400-e29b-41d4-a716-446655440000
+              time: "2025-01-01T12:00:00Z"
+              datacontenttype: application/json
+              data: {}
+      responses:
+        "204":
+          description: The CloudEvent was successfully received.
+
+
+components:
+  schemas:
+    Message:
+      type: object
+      properties:
+        kanaal:
+          type: string
+          description: De naam van het kanaal (`KANAAL.naam`) waar het bericht op
+            moet worden gepubliceerd.
+          maxLength: 50
+        source:
+          type: string
+          description: De identifier van de oorsprong van de notificatie, een systeem
+            of organisatie.
+          maxLength: 100
+        hoofdObject:
+          type: string
+          format: uri
+          title: hoofdobject
+          description: URL-referentie naar het hoofd object van de publicerende API
+            die betrekking heeft op de `resource`.
+        resource:
+          type: string
+          description: De resourcenaam waar de notificatie over gaat.
+          maxLength: 100
+        resourceUrl:
+          type: string
+          format: uri
+          description: URL-referentie naar de `resource` van de publicerende API.
+        actie:
+          type: string
+          description: De actie die door de publicerende API is gedaan. De publicerende
+            API specificeert de toegestane acties.
+          maxLength: 100
+        aanmaakdatum:
+          type: string
+          format: date-time
+          description: Datum en tijd waarop de actie heeft plaatsgevonden.
+        kenmerken:
+          type: object
+          additionalProperties:
+            type: string
+            title: kenmerk
+            description: Een waarde behorende bij de sleutel.
+            maxLength: 1000
+          description: Mapping van kenmerken (sleutel/waarde) van de notificatie.
+            De publicerende API specificeert de toegestane kenmerken.
+      required:
+      - aanmaakdatum
+      - actie
+      - hoofdObject
+      - kanaal
+      - resource
+      - resourceUrl
+
+    CloudEvent:
+      type: object
+      properties:
+        source:
+          type: string
+          format: uri-reference
+          example: https://openzaak.example.com
+          description: event source
+        dataschema:
+          type: string
+          format: uri
+          description: A schema that the data must follow
+        data:
+          nullable: true
+          description: extra data using the format defined in datacontentype
+        id:
+          type: string
+          description: event id
+          maxLength: 255
+        specversion:
+          type: string
+          description: cloudevent spec version used by the event
+          pattern: ^(\d+)\.(\d+)
+          maxLength: 50
+        type:
+          type: string
+          description: 'event type on which can be subscribed. Example: nl.overheid.zaken.zaak.created'
+          maxLength: 255
+        datacontenttype:
+          type: string
+          title: Data content type
+          description: 'content type of the (optional) cloudevent data. Example: application/json'
+          maxLength: 255
+        subject:
+          type: string
+          description: 'the events subject. Example: an uuid of a zaak'
+          maxLength: 255
+        time:
+          type: string
+          format: date-time
+          nullable: true
+          description: the timestamp of when the event happened
+      required:
+      - id
+      - source
+      - specversion
+      - type


### PR DESCRIPTION
Closes #390

**Changes**

- Add a separate consumer OpenAPI specification documenting webhook endpoints
- Document example webhook endpoints for classic notifications and CloudEvents
- Add example payloads for both notification types

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [ ] Any experimental features added in this PR are backwards compatible
  - [ ] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [ ] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-notificaties/wiki/Architectural-Decision-Records-(ADR))
