### PR TITLE
:construction_worker: [maykinmedia/open-api-workflows#60] Reenable OAS workflow and replace spectral with vacuum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         id: image-name
 
   open-api-ci:
-    uses: maykinmedia/open-api-workflows/.github/workflows/ci.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/ci.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     needs:
       - store-reusable-workflow-vars
     permissions:
@@ -106,7 +106,7 @@ jobs:
       django-settings-module: nrc.conf.ci
 
   open-api-publish:
-    uses: maykinmedia/open-api-workflows/.github/workflows/publish.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/publish.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     needs:
       - store-reusable-workflow-vars
       - open-api-ci

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   open-api-workflow-code-quality:
-    uses: maykinmedia/open-api-workflows/.github/workflows/code-quality.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/code-quality.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
     with:
       python-version: '3.12'
       node-version: '24'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,4 +21,4 @@ permissions:
 
 jobs:
   open-api-workflow-code-analysis:
-    uses: maykinmedia/open-api-workflows/.github/workflows/code-analysis.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/code-analysis.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0

--- a/.github/workflows/oaf-check.yml
+++ b/.github/workflows/oaf-check.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   open-api-workflow-check-oas:
-    uses: maykinmedia/open-api-workflows/.github/workflows/oaf-check.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/oaf-check.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
 
     with:
       python-version: '3.12'

--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -1,34 +1,34 @@
 
-# name: OAS
+name: OAS
 
-# on:
-#   push:
-#     branches:
-#       - main
-#       - stable/*
-#     tags:
-#       - '*'
-#   pull_request:
-#   workflow_dispatch:
+on:
+  push:
+    branches:
+      - main
+      - stable/*
+    tags:
+      - '*'
+  pull_request:
+  workflow_dispatch:
 
-# # least privilege as default, should be overridden per job if necessary
-# permissions:
-#   contents: read
+# least privilege as default, should be overridden per job if necessary
+permissions:
+  contents: read
 
-# jobs:
-#   oas:
-#     name: Checks
-#     uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
-#     with:
-#       python-version: '3.12'
-#       apt-packages: 'libgdal-dev gdal-bin'
-#       django-settings-module: nrc.conf.ci
-#       oas-generate-command: ./bin/generate_schema.sh
-#       schema-path: src/openapi.yaml
-#       oas-artifact-name: nrc-api-oas
-#       node-version-file: '.nvmrc'
-#       spectral-version: '^6.15.0'
-#       openapi-to-postman-version: '^5.0.0'
-#       postman-artifact-name: nrc-api-postman-collection
-#       openapi-generator-version: '^2.20.0'
-#       spectral-ruleset: ruleset.yaml
+jobs:
+  oas:
+    name: Checks
+    uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0
+    with:
+      python-version: '3.12'
+      apt-packages: 'libgdal-dev gdal-bin'
+      django-settings-module: nrc.conf.ci
+      oas-generate-command: ./bin/generate_schema.sh
+      schema-path: src/openapi.yaml
+      oas-artifact-name: nrc-api-oas
+      node-version-file: '.nvmrc'
+      openapi-to-postman-version: '^5.0.0'
+      postman-artifact-name: ${{ matrix.component }}-api-postman-collection
+      openapi-generator-version: '^2.20.0'
+      spectral-ruleset: ruleset.yaml
+      vacuum-custom-functions: vacuum_functions

--- a/.github/workflows/quick-start.yml
+++ b/.github/workflows/quick-start.yml
@@ -15,4 +15,4 @@ permissions:
 
 jobs:
   open-api-workflow-quick-start:
-    uses: maykinmedia/open-api-workflows/.github/workflows/quick-start.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+    uses: maykinmedia/open-api-workflows/.github/workflows/quick-start.yml@31eaea25acd18bb681fe0d01b2452c3dd8d299b9 # v7.0.0

--- a/ruleset.yaml
+++ b/ruleset.yaml
@@ -1,4 +1,7 @@
 # 2.1 ruleset got changed without a version increase
-extends: https://static.developer.overheid.nl/adr/2.1/ruleset.yaml
+# vacuum supports the extends syntax and can fetch external rulesets, but the original
+# URL (https://static.developer.overheid.nl/adr/2.1/ruleset.yaml) returns the linter as
+# a file download, which vacuum doesn't support currently
+extends: https://raw.githubusercontent.com/Logius-standaarden/API-Design-Rules/refs/tags/v2.1.0/linter/spectral.yml
 rules:
   paths-open-api-json-resource-exists: warn

--- a/vacuum_functions/or.js
+++ b/vacuum_functions/or.js
@@ -1,0 +1,24 @@
+// The Logius API design rules make use of the function `or`, which vacuum does not
+// support
+function getSchema() {
+  return {
+    name: "or",
+    description: "Passes if any configured property exists."
+  };
+}
+
+function runRule(input) {
+  const properties = context.rule.then.functionOptions.properties || [];
+
+  for (const property of properties) {
+    if (Object.prototype.hasOwnProperty.call(input, property)) {
+      return [];
+    }
+  }
+
+  return [
+    {
+      message: "None of the required properties were found."
+    }
+  ];
+}


### PR DESCRIPTION
Closes maykinmedia/open-api-workflows#60 partially

**Changes**

* Reenable OAS workflow and replace spectral with vacuum

**Checklist**

Check off the items that are completed or not relevant.

- Experimental features/changes

  - [x] Any experimental features added in this PR are backwards compatible
  - [x] Any experimental features added in this PR are documented in the `docs/api/experimental.rst` page

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Architectural design record

  - [x] If a design decision was made that changes functionality, create an architectural design record for it [here](https://github.com/open-zaak/open-notificaties/wiki/Architectural-Decision-Records-(ADR))
